### PR TITLE
Added negative scenarios for PetStore API and PageTitle UI test

### DIFF
--- a/API/Features/PetStoreNegativeScenarios.feature
+++ b/API/Features/PetStoreNegativeScenarios.feature
@@ -1,0 +1,11 @@
+Feature: PetStore API Negative Scenarios
+
+  Scenario: Delete a non-existent pet
+    Given I have a pet ID that does not exist
+    When I send a DELETE request to the PetStore API
+    Then I should receive a 404 Not Found response
+
+  Scenario: Delete a pet with invalid ID
+    Given I have an invalid pet ID
+    When I send a DELETE request to the PetStore API
+    Then I should receive a 400 Bad Request response

--- a/API/StepDefinitions/PetStoreNegativeScenariosSteps.cs
+++ b/API/StepDefinitions/PetStoreNegativeScenariosSteps.cs
@@ -1,0 +1,50 @@
+using TechTalk.SpecFlow;
+using NUnit.Framework;
+using RestSharp;
+using API.Clients;
+
+namespace API.StepDefinitions
+{
+    [Binding]
+    public class PetStoreNegativeScenariosSteps
+    {
+        private readonly PetStoreApiClient _client;
+        private IRestResponse _response;
+        private string _petId;
+
+        public PetStoreNegativeScenariosSteps(PetStoreApiClient client)
+        {
+            _client = client;
+        }
+
+        [Given("I have a pet ID that does not exist")]
+        public void GivenIHaveAPetIDThatDoesNotExist()
+        {
+            _petId = "999999"; // Assuming this ID does not exist
+        }
+
+        [Given("I have an invalid pet ID")]
+        public void GivenIHaveAnInvalidPetID()
+        {
+            _petId = "invalid-id";
+        }
+
+        [When("I send a DELETE request to the PetStore API")]
+        public void WhenISendADELETERequestToThePetStoreAPI()
+        {
+            _response = _client.DeletePet(_petId);
+        }
+
+        [Then("I should receive a 404 Not Found response")]
+        public void ThenIShouldReceiveA404NotFoundResponse()
+        {
+            Assert.AreEqual(404, (int)_response.StatusCode);
+        }
+
+        [Then("I should receive a 400 Bad Request response")]
+        public void ThenIShouldReceiveA400BadRequestResponse()
+        {
+            Assert.AreEqual(400, (int)_response.StatusCode);
+        }
+    }
+}

--- a/UI/Features/BlazeDemoPageTitle.feature
+++ b/UI/Features/BlazeDemoPageTitle.feature
@@ -1,0 +1,5 @@
+Feature: BlazeDemo Page Title
+
+  Scenario: Verify the page title of BlazeDemo
+    Given I navigate to the BlazeDemo website
+    Then the page title should be "BlazeDemo"

--- a/UI/StepDefinitions/BlazeDemoPageTitleSteps.cs
+++ b/UI/StepDefinitions/BlazeDemoPageTitleSteps.cs
@@ -1,0 +1,32 @@
+using TechTalk.SpecFlow;
+using NUnit.Framework;
+using OpenQA.Selenium;
+using UI.Pages;
+
+namespace UI.StepDefinitions
+{
+    [Binding]
+    public class BlazeDemoPageTitleSteps
+    {
+        private readonly IWebDriver _driver;
+        private readonly BlazeDemoPage _blazeDemoPage;
+
+        public BlazeDemoPageTitleSteps(IWebDriver driver)
+        {
+            _driver = driver;
+            _blazeDemoPage = new BlazeDemoPage(_driver);
+        }
+
+        [Given("I navigate to the BlazeDemo website")]
+        public void GivenINavigateToTheBlazeDemoWebsite()
+        {
+            _blazeDemoPage.NavigateToBlazeDemo();
+        }
+
+        [Then("the page title should be \"BlazeDemo\"")]
+        public void ThenThePageTitleShouldBeBlazeDemo()
+        {
+            Assert.AreEqual("BlazeDemo", _driver.Title);
+        }
+    }
+}


### PR DESCRIPTION
Implemented negative scenarios for the delete operation in the PetStore API and added a PageTitle UI test for 'https://blazedemo.com/'.

closes #<issue_number>