### PR TITLE
Added negative scenarios for PetStore API delete operation and UI test for BlazeDemo page title

### DIFF
--- a/API/Features/PetStoreNegative.feature
+++ b/API/Features/PetStoreNegative.feature
@@ -1,0 +1,21 @@
+@PetStoreAPI @Regression @APITesting
+Feature: Pet Store API Negative Scenarios
+  As an API consumer
+  I want to validate negative scenarios for pet operations
+  So that I can ensure proper error handling
+
+Background:
+	Given the PetStore API is available and accessible
+
+@DeletePet @NegativeScenario
+Scenario: Delete a pet with an invalid ID
+	When I delete the pet with invalid ID
+	Then the response status code should be 404
+	And an error message should be returned
+
+@DeletePet @NegativeScenario
+Scenario: Delete a pet with a non-existent ID
+	Given I have a non-existent pet ID
+	When I delete the pet with non-existent ID
+	Then the response status code should be 404
+	And an error message should be returned

--- a/API/StepDefinitions/PetStoreNegativeSteps.cs
+++ b/API/StepDefinitions/PetStoreNegativeSteps.cs
@@ -1,0 +1,59 @@
+using TechTalk.SpecFlow;
+using AutomationFramework.API.BusinessLogic;
+using AutomationFramework.Core.Config;
+using RestSharp;
+using FluentAssertions;
+using Serilog;
+
+namespace AutomationFramework.API.StepDefinitions
+{
+    [Binding]
+    public class PetStoreNegativeSteps
+    {
+        private readonly PetBusinessLogic _petBusinessLogic;
+        private RestResponse _response;
+        private ScenarioContext _scenarioContext;
+        private string InvalidPetId = "InvalidPetID";
+        private string NonExistentPetId = "NonExistentPetID";
+
+        public PetStoreNegativeSteps(ScenarioContext scenarioContext)
+        {
+            var baseUrl = ConfigManager.GetConfigValue<string>("ApiBaseUrl");
+            _scenarioContext = scenarioContext;
+            _petBusinessLogic = new PetBusinessLogic(baseUrl);
+        }
+
+        [When("I delete the pet with invalid ID")]
+        public void WhenIDeleteThePetWithInvalidID()
+        {
+            _response = _petBusinessLogic.DeletePet(-1); // Assuming -1 is an invalid ID
+        }
+
+        [Then("the response status code should be (.*)")]
+        public void ThenTheResponseStatusCodeShouldBe(int expectedStatusCode)
+        {
+            _response.StatusCode.Should().Be((System.Net.HttpStatusCode)expectedStatusCode);
+            Log.Information($"Verified response status code: {_response.StatusCode}");
+        }
+
+        [Then("an error message should be returned")]
+        public void ThenAnErrorMessageShouldBeReturned()
+        {
+            _response.Content.Should().Contain("error");
+            Log.Information($"Error message returned: {_response.Content}");
+        }
+
+        [Given("I have a non-existent pet ID")]
+        public void GivenIHaveANonExistentPetID()
+        {
+            ScenarioContextHelper.SetOrReplace(_scenarioContext, NonExistentPetId, 999999); // Assuming 999999 is a non-existent ID
+        }
+
+        [When("I delete the pet with non-existent ID")]
+        public void WhenIDeleteThePetWithNonExistentID()
+        {
+            var petId = _scenarioContext.Get<long>(NonExistentPetId);
+            _response = _petBusinessLogic.DeletePet(petId);
+        }
+    }
+}

--- a/UI/Features/PageTitle.feature
+++ b/UI/Features/PageTitle.feature
@@ -1,0 +1,10 @@
+@PageTitle @Regression @UITesting
+Feature: Validate Page Title
+  As a user
+  I want to validate the page title of BlazeDemo
+  So that I can ensure the correct page is loaded
+
+@PageTitle @PositiveScenario
+Scenario: Validate the page title of BlazeDemo
+  Given I navigate to the BlazeDemo homepage
+  Then the page title should be "BlazeDemo"

--- a/UI/StepDefinitions/PageTitleSteps.cs
+++ b/UI/StepDefinitions/PageTitleSteps.cs
@@ -1,0 +1,35 @@
+using TechTalk.SpecFlow;
+using OpenQA.Selenium;
+using OpenQA.Selenium.Chrome;
+using FluentAssertions;
+using Serilog;
+
+namespace AutomationFramework.UI.StepDefinitions
+{
+    [Binding]
+    public class PageTitleSteps
+    {
+        private IWebDriver _driver;
+
+        public PageTitleSteps()
+        {
+            _driver = new ChromeDriver();
+        }
+
+        [Given("I navigate to the BlazeDemo homepage")]
+        public void GivenINavigateToTheBlazeDemoHomepage()
+        {
+            _driver.Navigate().GoToUrl("https://blazedemo.com/");
+            Log.Information("Navigated to BlazeDemo homepage.");
+        }
+
+        [Then("the page title should be {string}")]
+        public void ThenThePageTitleShouldBe(string expectedTitle)
+        {
+            var actualTitle = _driver.Title;
+            actualTitle.Should().Be(expectedTitle);
+            Log.Information($"Verified page title: {actualTitle}");
+            _driver.Quit();
+        }
+    }
+}


### PR DESCRIPTION
- Added two negative scenarios for the delete operation in the PetStore API.
- Created corresponding step definitions for the negative scenarios.
- Added a UI test to validate the page title of BlazeDemo.
- Created corresponding step definitions for the UI test.

This PR ensures proper error handling for invalid and non-existent pet IDs in the PetStore API and validates the correct page title for BlazeDemo.