### PR TITLE
Added negative scenarios for PetStore API delete operation and UI test for BlazeDemo page title

### DIFF
--- a/API/Features/PetStoreNegative.feature
+++ b/API/Features/PetStoreNegative.feature
@@ -1,0 +1,20 @@
+@PetStoreAPI @Regression @APITesting
+Feature: Pet Store API Negative Scenarios
+  As an API consumer
+  I want to handle errors gracefully
+  So that I can ensure robustness of the API
+
+Background:
+	Given the PetStore API is available and accessible
+
+@DeletePet @NegativeScenario
+Scenario: Attempt to delete a pet with an invalid ID
+	When I attempt to delete a pet with ID "invalid-id"
+	Then the response status code should be 404
+	And the response message should indicate that the pet was not found
+
+@DeletePet @NegativeScenario
+Scenario: Attempt to delete a pet with a non-existent ID
+	When I attempt to delete a pet with ID "999999"
+	Then the response status code should be 404
+	And the response message should indicate that the pet was not found

--- a/API/StepDefinitions/PetStoreNegativeSteps.cs
+++ b/API/StepDefinitions/PetStoreNegativeSteps.cs
@@ -1,0 +1,44 @@
+using TechTalk.SpecFlow;
+using AutomationFramework.API.BusinessLogic;
+using AutomationFramework.Core.Config;
+using RestSharp;
+using FluentAssertions;
+using Serilog;
+
+namespace AutomationFramework.API.StepDefinitions
+{
+    [Binding]
+    public class PetStoreNegativeSteps
+    {
+        private readonly PetBusinessLogic _petBusinessLogic;
+        private RestResponse _response;
+        private ScenarioContext _scenarioContext;
+
+        public PetStoreNegativeSteps(ScenarioContext scenarioContext)
+        {
+            var baseUrl = ConfigManager.GetConfigValue<string>("ApiBaseUrl");
+            _scenarioContext = scenarioContext;
+            _petBusinessLogic = new PetBusinessLogic(baseUrl);
+        }
+
+        [When(@"I attempt to delete a pet with ID \"(.*)\"")]
+        public void WhenIAttemptToDeleteAPetWithID(string petId)
+        {
+            _response = _petBusinessLogic.DeletePet(petId);
+        }
+
+        [Then(@"the response status code should be (.*)")]
+        public void ThenTheResponseStatusCodeShouldBe(int expectedStatusCode)
+        {
+            _response.StatusCode.Should().Be((System.Net.HttpStatusCode)expectedStatusCode);
+            Log.Information($"Verified response status code: {_response.StatusCode}");
+        }
+
+        [Then(@"the response message should indicate that the pet was not found")]
+        public void ThenTheResponseMessageShouldIndicateThatThePetWasNotFound()
+        {
+            _response.Content.Should().Contain("Pet not found");
+            Log.Information("Verified response message indicates pet was not found.");
+        }
+    }
+}

--- a/UI/Features/PageTitle.feature
+++ b/UI/Features/PageTitle.feature
@@ -1,0 +1,9 @@
+@PageTitle @UITesting
+Feature: Validate Page Title
+  As a user
+  I want to verify the page title of BlazeDemo
+  So that I can ensure the correct page is loaded
+
+Scenario: Verify the page title of BlazeDemo homepage
+  Given I navigate to the BlazeDemo homepage
+  Then the page title should be "BlazeDemo"

--- a/UI/StepDefinitions/PageTitleSteps.cs
+++ b/UI/StepDefinitions/PageTitleSteps.cs
@@ -1,0 +1,35 @@
+using TechTalk.SpecFlow;
+using OpenQA.Selenium;
+using FluentAssertions;
+using AutomationFramework.Core.Config;
+using Serilog;
+
+namespace AutomationFramework.UI.StepDefinitions
+{
+    [Binding]
+    public class PageTitleSteps
+    {
+        private readonly IWebDriver _driver;
+
+        public PageTitleSteps(ScenarioContext scenarioContext)
+        {
+            _driver = (IWebDriver)scenarioContext["WebDriver"];
+        }
+
+        [Given(@"I navigate to the BlazeDemo homepage")]
+        public void GivenINavigateToTheBlazeDemoHomepage()
+        {
+            var url = ConfigManager.GetConfigValue<string>("BlazeDemoUrl");
+            _driver.Navigate().GoToUrl(url);
+            Log.Information("Navigated to BlazeDemo homepage.");
+        }
+
+        [Then(@"the page title should be \"(.*)\"")]
+        public void ThenThePageTitleShouldBe(string expectedTitle)
+        {
+            var actualTitle = _driver.Title;
+            actualTitle.Should().Be(expectedTitle, $"Page title should be {expectedTitle} but was {actualTitle}");
+            Log.Information($"Verified page title: {actualTitle}");
+        }
+    }
+}


### PR DESCRIPTION
- Added two negative scenarios for the delete operation in PetStore API in a new feature file `PetStoreNegative.feature`.
- Created corresponding step definitions in `PetStoreNegativeSteps.cs`.
- Added a new UI test to verify the page title of BlazeDemo homepage in `PageTitle.feature`.
- Created corresponding step definitions in `PageTitleSteps.cs`.

This PR ensures that the API handles errors gracefully and verifies the correct page title for BlazeDemo.