### PR TITLE
Added negative scenarios for PetStore API delete operation and UI test for BlazeDemo page title

### DIFF
--- a/API/Features/PetStoreNegative.feature
+++ b/API/Features/PetStoreNegative.feature
@@ -1,0 +1,21 @@
+@PetStoreAPI @Regression @APITesting
+Feature: Pet Store API Negative Operations
+  As an API consumer
+  I want to perform negative tests on CRUD operations for pets
+  So that I can ensure the API handles errors gracefully
+
+Background:
+	Given the PetStore API is available and accessible
+
+@DeletePet @NegativeScenario
+Scenario: Delete a pet with an invalid ID
+	When I delete the pet with invalid ID
+	Then the response status code should be 404
+	And an appropriate error message should be returned
+
+@DeletePet @NegativeScenario
+Scenario: Delete a pet with a non-existent ID
+	Given I have a non-existent pet ID
+	When I delete the pet with non-existent ID
+	Then the response status code should be 404
+	And an appropriate error message should be returned

--- a/API/StepDefinitions/PetStoreNegativeSteps.cs
+++ b/API/StepDefinitions/PetStoreNegativeSteps.cs
@@ -1,0 +1,57 @@
+using TechTalk.SpecFlow;
+using AutomationFramework.API.BusinessLogic;
+using AutomationFramework.Core.Config;
+using RestSharp;
+using FluentAssertions;
+using Serilog;
+
+namespace AutomationFramework.API.StepDefinitions
+{
+    [Binding]
+    public class PetStoreNegativeSteps
+    {
+        private readonly PetBusinessLogic _petBusinessLogic;
+        private RestResponse _response;
+        private ScenarioContext _scenarioContext;
+        private string PetId = "PetID";
+        public PetStoreNegativeSteps(ScenarioContext scenarioContext)
+        {
+            var baseUrl = ConfigManager.GetConfigValue<string>("ApiBaseUrl");
+            _scenarioContext = scenarioContext;
+            _petBusinessLogic = new PetBusinessLogic(baseUrl);
+        }
+
+        [When("I delete the pet with invalid ID")]
+        public void WhenIDeleteThePetWithInvalidID()
+        {
+            _response = _petBusinessLogic.DeletePet(-1); // Assuming -1 is an invalid ID
+        }
+
+        [Then("the response status code should be (.*)")]
+        public void ThenTheResponseStatusCodeShouldBe(int expectedStatusCode)
+        {
+            _response.StatusCode.Should().Be((System.Net.HttpStatusCode)expectedStatusCode);
+            Log.Information($"Verified response status code: {_response.StatusCode}");
+        }
+
+        [Then("an appropriate error message should be returned")]
+        public void ThenAnAppropriateErrorMessageShouldBeReturned()
+        {
+            _response.Content.Should().Contain("Pet not found"); // Assuming the error message contains this text
+            Log.Information($"Verified error message: {_response.Content}");
+        }
+
+        [Given("I have a non-existent pet ID")]
+        public void GivenIHaveANonExistentPetID()
+        {
+            ScenarioContextHelper.SetOrReplace(_scenarioContext, PetId, 999999); // Assuming 999999 is a non-existent ID
+        }
+
+        [When("I delete the pet with non-existent ID")]
+        public void WhenIDeleteThePetWithNonExistentID()
+        {
+            var petId = _scenarioContext.Get<long>(PetId);
+            _response = _petBusinessLogic.DeletePet(petId);
+        }
+    }
+}

--- a/UI/Features/PageTitle.feature
+++ b/UI/Features/PageTitle.feature
@@ -1,0 +1,10 @@
+@PageTitle @UI @Regression
+Feature: Validate Page Title
+  As a user
+  I want to validate the page title of BlazeDemo website
+  So that I can ensure the correct title is displayed
+
+@Smoke @PageTitle
+Scenario: Validate the page title of BlazeDemo
+  Given I navigate to the BlazeDemo website
+  Then the page title should be "BlazeDemo"

--- a/UI/StepDefinitions/PageTitleSteps.cs
+++ b/UI/StepDefinitions/PageTitleSteps.cs
@@ -1,0 +1,34 @@
+using TechTalk.SpecFlow;
+using OpenQA.Selenium;
+using AutomationFramework.Core.Singleton;
+using FluentAssertions;
+using Serilog;
+
+namespace AutomationFramework.UI.StepDefinitions
+{
+    [Binding]
+    public class PageTitleSteps
+    {
+        private readonly IWebDriver _driver;
+
+        public PageTitleSteps()
+        {
+            _driver = BrowserFactory.GetDriver();
+        }
+
+        [Given("I navigate to the BlazeDemo website")]
+        public void GivenINavigateToTheBlazeDemoWebsite()
+        {
+            _driver.Navigate().GoToUrl("https://blazedemo.com/");
+            Log.Information("Navigated to BlazeDemo website.");
+        }
+
+        [Then("the page title should be {string}")]
+        public void ThenThePageTitleShouldBe(string expectedTitle)
+        {
+            var actualTitle = _driver.Title;
+            actualTitle.Should().Be(expectedTitle);
+            Log.Information($"Verified page title. Expected: {expectedTitle}, Actual: {actualTitle}");
+        }
+    }
+}


### PR DESCRIPTION
Implemented two negative scenarios for the delete operation in the PetStore API:
1. Delete a pet with an invalid ID
2. Delete a pet with a non-existent ID

Added a UI test to validate the page title of the BlazeDemo website.

closes #3