### PR TITLE
Added UI test for verifying the page title of BlazeDemo homepage

### DIFF
--- a/UI/Features/PageTitle.feature
+++ b/UI/Features/PageTitle.feature
@@ -1,0 +1,4 @@
+Feature: Page Title Verification
+  Scenario: Verify the page title of BlazeDemo homepage
+    Given I navigate to the BlazeDemo homepage
+    Then the page title should be "BlazeDemo"

--- a/UI/StepDefinitions/PageTitleSteps.cs
+++ b/UI/StepDefinitions/PageTitleSteps.cs
@@ -1,0 +1,29 @@
+using NUnit.Framework;
+using OpenQA.Selenium;
+using TechTalk.SpecFlow;
+
+namespace AutomationFramework.UI.StepDefinitions
+{
+    [Binding]
+    public class PageTitleSteps
+    {
+        private readonly IWebDriver _driver;
+
+        public PageTitleSteps(IWebDriver driver)
+        {
+            _driver = driver;
+        }
+
+        [Given(@"I navigate to the BlazeDemo homepage")]
+        public void GivenINavigateToTheBlazeDemoHomepage()
+        {
+            _driver.Navigate().GoToUrl("https://blazedemo.com/");
+        }
+
+        [Then(@"the page title should be "BlazeDemo"")]
+        public void ThenThePageTitleShouldBeBlazeDemo()
+        {
+            Assert.AreEqual("BlazeDemo", _driver.Title);
+        }
+    }
+}


### PR DESCRIPTION
- Created a new feature file `PageTitle.feature` for the page title verification scenario.
- Added step definitions in `PageTitleSteps.cs` to navigate to the BlazeDemo homepage and verify the page title.

This PR adds a simple UI test to ensure the page title of BlazeDemo homepage is correctly displayed.