### PR TITLE
Add BlazeDemo Page Title Test

### DIFF
--- a/UI/Features/BlazeDemoPageTitle.feature
+++ b/UI/Features/BlazeDemoPageTitle.feature
@@ -1,0 +1,5 @@
+Feature: Verify the page title of BlazeDemo website
+
+  Scenario: Verify the page title of BlazeDemo homepage
+    Given I navigate to the BlazeDemo homepage
+    Then the page title should be "BlazeDemo"

--- a/UI/Pages/BlazeDemoHomePage.cs
+++ b/UI/Pages/BlazeDemoHomePage.cs
@@ -1,0 +1,21 @@
+using OpenQA.Selenium;
+using OpenQA.Selenium.Support.PageObjects;
+
+namespace UI.Pages
+{
+    public class BlazeDemoHomePage
+    {
+        private readonly IWebDriver _driver;
+
+        public BlazeDemoHomePage(IWebDriver driver)
+        {
+            _driver = driver;
+            PageFactory.InitElements(driver, this);
+        }
+
+        public string GetPageTitle()
+        {
+            return _driver.Title;
+        }
+    }
+}

--- a/UI/StepDefinitions/BlazeDemoSteps.cs
+++ b/UI/StepDefinitions/BlazeDemoSteps.cs
@@ -1,0 +1,33 @@
+using NUnit.Framework;
+using OpenQA.Selenium;
+using TechTalk.SpecFlow;
+using UI.Pages;
+
+namespace UI.StepDefinitions
+{
+    [Binding]
+    public class BlazeDemoSteps
+    {
+        private readonly IWebDriver _driver;
+        private readonly BlazeDemoHomePage _blazeDemoHomePage;
+
+        public BlazeDemoSteps(IWebDriver driver)
+        {
+            _driver = driver;
+            _blazeDemoHomePage = new BlazeDemoHomePage(driver);
+        }
+
+        [Given(@"I navigate to the BlazeDemo homepage")]
+        public void GivenINavigateToTheBlazeDemoHomepage()
+        {
+            _driver.Navigate().GoToUrl("https://blazedemo.com/");
+        }
+
+        [Then(@"the page title should be "BlazeDemo"")]
+        public void ThenThePageTitleShouldBeBlazeDemo()
+        {
+            string pageTitle = _blazeDemoHomePage.GetPageTitle();
+            Assert.That(pageTitle, Is.EqualTo("BlazeDemo"));
+        }
+    }
+}


### PR DESCRIPTION
Added a new UI test to verify the page title of the BlazeDemo homepage. This includes a new feature file, page class, and step definitions.

closes #3