### PR TITLE
Added negative scenarios for GET operation in PetStore API

### DIFF
--- a/AutomationFramework/API/Features/PetStoreNegativeScenarios.feature
+++ b/AutomationFramework/API/Features/PetStoreNegativeScenarios.feature
@@ -1,0 +1,17 @@
+@PetStoreAPI @Regression @APITesting @NegativeScenario
+Feature: Pet Store API Negative Scenarios
+  As an API consumer
+  I want to verify the negative scenarios for PetStore API
+  So that I can ensure the API handles errors gracefully
+
+@RetrievePet @NegativeScenario
+Scenario: Retrieve a pet with an invalid ID
+  Given the PetStore API is available and accessible
+  When I retrieve the pet by ID with an invalid ID
+  Then the response status code should be 404
+
+@RetrievePet @NegativeScenario
+Scenario: Retrieve a pet with a non-existent ID
+  Given the PetStore API is available and accessible
+  When I retrieve the pet by ID with a non-existent ID
+  Then the response status code should be 404

--- a/AutomationFramework/API/StepDefinitions/PetStoreNegativeSteps.cs
+++ b/AutomationFramework/API/StepDefinitions/PetStoreNegativeSteps.cs
@@ -1,0 +1,42 @@
+using TechTalk.SpecFlow;
+using AutomationFramework.API.BusinessLogic;
+using AutomationFramework.Core.Config;
+using RestSharp;
+using FluentAssertions;
+using Serilog;
+
+namespace AutomationFramework.API.StepDefinitions
+{
+    [Binding]
+    public class PetStoreNegativeSteps
+    {
+        private readonly PetBusinessLogic _petBusinessLogic;
+        private RestResponse _response;
+        private ScenarioContext _scenarioContext;
+        public PetStoreNegativeSteps(ScenarioContext scenarioContext)
+        {
+            var baseUrl = ConfigManager.GetConfigValue<string>("ApiBaseUrl");
+            _scenarioContext = scenarioContext;
+            _petBusinessLogic = new PetBusinessLogic(baseUrl);
+        }
+
+        [When(@"I retrieve the pet by ID with an invalid ID")]
+        public void WhenIRetrieveThePetByIDWithAnInvalidID()
+        {
+            _response = _petBusinessLogic.GetPetById(-1); // Assuming -1 is an invalid ID
+        }
+
+        [When(@"I retrieve the pet by ID with a non-existent ID")]
+        public void WhenIRetrieveThePetByIDWithANonExistentID()
+        {
+            _response = _petBusinessLogic.GetPetById(999999); // Assuming 999999 is a non-existent ID
+        }
+
+        [Then(@"the response status code should be (.*)")]
+        public void ThenTheResponseStatusCodeShouldBe(int expectedStatusCode)
+        {
+            _response.StatusCode.Should().Be((System.Net.HttpStatusCode)expectedStatusCode);
+            Log.Information($"Verified response status code: {_response.StatusCode}");
+        }
+    }
+}


### PR DESCRIPTION
Added two negative scenarios for the GET operation in the PetStore API to verify status codes. Created new feature file `PetStoreNegativeScenarios.feature` and step definition file `PetStoreNegativeSteps.cs`. The scenarios include retrieving a pet with an invalid ID and a non-existent ID, both expecting a 404 status code.