### PR TITLE
Add negative scenario for Gmail login

### DIFF
--- a/UI/StepDefinitions/GmailLoginNegativeSteps.cs
+++ b/UI/StepDefinitions/GmailLoginNegativeSteps.cs
@@ -1,0 +1,40 @@
+using TechTalk.SpecFlow;
+using AutomationFramework.UI.BusinessLogic;
+using AutomationFramework.Core.Config;
+using OpenQA.Selenium;
+using FluentAssertions;
+
+namespace AutomationFramework.UI.StepDefinitions
+{
+    [Binding]
+    public class GmailLoginNegativeSteps
+    {
+        private readonly IWebDriver _driver;
+        private readonly GmailLoginBusinessLogic _gmailLoginBusinessLogic;
+
+        public GmailLoginNegativeSteps(ScenarioContext scenarioContext)
+        {
+            _driver = (IWebDriver)scenarioContext["WebDriver"];
+            _gmailLoginBusinessLogic = new GmailLoginBusinessLogic(_driver);
+        }
+
+        [Given(@"I navigate to Gmail login page")]
+        public void GivenINavigateToGmailLoginPage()
+        {
+            var url = ConfigManager.GetConfigValue<string>("GmailLoginUrl");
+            _driver.Navigate().GoToUrl(url);
+        }
+
+        [When(@"I enter invalid "(.*)" and "(.*)"")]
+        public void WhenIEnterInvalidCredentials(string email, string password)
+        {
+            _gmailLoginBusinessLogic.Login(email, password);
+        }
+
+        [Then(@"I should see an error message for invalid credentials")]
+        public void ThenIShouldSeeAnErrorMessageForInvalidCredentials()
+        {
+            _gmailLoginBusinessLogic.VerifyErrorMessageVisible().Should().BeTrue("Error message should be displayed for invalid credentials.");
+        }
+    }
+}


### PR DESCRIPTION
Added step definition for the negative scenario where invalid credentials are provided during Gmail login.

- Created a new step definition file `GmailLoginNegativeSteps.cs`.

This PR addresses the requirement to add a negative scenario for Gmail login.