### PR TITLE
Add PetStore API delete negative scenarios and Blazedemo UI test

### DIFF
--- a/API/Features/PetStoreDeleteNegative.feature
+++ b/API/Features/PetStoreDeleteNegative.feature
@@ -1,0 +1,25 @@
+@PetStoreAPI @Regression @APITesting @DeletePet
+Feature: Pet Store API Delete Operations - Negative Scenarios
+  As an API consumer
+  I want to test negative scenarios for delete operations on pets
+  So that I can ensure the API handles errors correctly
+
+Background:
+	Given the PetStore API is available and accessible
+
+@NegativeScenario
+Scenario: Attempt to delete a non-existent pet
+	Given I have an invalid pet ID
+	When I attempt to delete the pet with the invalid ID
+	Then the response status code should be 404
+	And the response should indicate that the pet was not found
+
+@NegativeScenario
+Scenario: Attempt to delete a pet with invalid API key
+	Given I have successfully created a pet with the following details
+		| Name  | Status    | Category | Tags |
+		| Rocky | available | Dog      | Loyal |
+	And I have an invalid API key
+	When I attempt to delete the pet with the invalid API key
+	Then the response status code should be 401
+	And the response should indicate an authentication error

--- a/API/StepDefinitions/PetStoreDeleteNegativeSteps.cs
+++ b/API/StepDefinitions/PetStoreDeleteNegativeSteps.cs
@@ -1,0 +1,72 @@
+using AutomationFramework.API.BusinessLogic;
+using AutomationFramework.API.Clients;
+using AutomationFramework.Core.Utilities;
+using NUnit.Framework;
+using TechTalk.SpecFlow;
+
+namespace AutomationFramework.API.StepDefinitions
+{
+    [Binding]
+    public class PetStoreDeleteNegativeSteps
+    {
+        private readonly PetStoreApiClient _petStoreApiClient;
+        private readonly PetBusinessLogic _petBusinessLogic;
+        private readonly ScenarioContext _scenarioContext;
+
+        public PetStoreDeleteNegativeSteps(PetStoreApiClient petStoreApiClient, PetBusinessLogic petBusinessLogic, ScenarioContext scenarioContext)
+        {
+            _petStoreApiClient = petStoreApiClient;
+            _petBusinessLogic = petBusinessLogic;
+            _scenarioContext = scenarioContext;
+        }
+
+        [Given(@"I have an invalid pet ID")]
+        public void GivenIHaveAnInvalidPetId()
+        {
+            _scenarioContext["InvalidPetId"] = -1; // Using a negative ID as an invalid ID
+        }
+
+        [When(@"I attempt to delete the pet with the invalid ID")]
+        public async Task WhenIAttemptToDeleteThePetWithTheInvalidId()
+        {
+            var invalidPetId = (int)_scenarioContext["InvalidPetId"];
+            var response = await _petStoreApiClient.DeletePetAsync(invalidPetId);
+            _scenarioContext["ApiResponse"] = response;
+        }
+
+        [Given(@"I have an invalid API key")]
+        public void GivenIHaveAnInvalidApiKey()
+        {
+            _petStoreApiClient.SetInvalidApiKey();
+        }
+
+        [When(@"I attempt to delete the pet with the invalid API key")]
+        public async Task WhenIAttemptToDeleteThePetWithTheInvalidApiKey()
+        {
+            var petId = (int)_scenarioContext["PetId"];
+            var response = await _petStoreApiClient.DeletePetAsync(petId);
+            _scenarioContext["ApiResponse"] = response;
+        }
+
+        [Then(@"the response status code should be (.*)")]
+        public void ThenTheResponseStatusCodeShouldBe(int expectedStatusCode)
+        {
+            var response = (RestSharp.RestResponse)_scenarioContext["ApiResponse"];
+            Assert.AreEqual(expectedStatusCode, (int)response.StatusCode);
+        }
+
+        [Then(@"the response should indicate that the pet was not found")]
+        public void ThenTheResponseShouldIndicateThatThePetWasNotFound()
+        {
+            var response = (RestSharp.RestResponse)_scenarioContext["ApiResponse"];
+            Assert.IsTrue(response.Content.Contains("Pet not found"));
+        }
+
+        [Then(@"the response should indicate an authentication error")]
+        public void ThenTheResponseShouldIndicateAnAuthenticationError()
+        {
+            var response = (RestSharp.RestResponse)_scenarioContext["ApiResponse"];
+            Assert.IsTrue(response.Content.Contains("Invalid API key"));
+        }
+    }
+}

--- a/UI/Features/BlazedemoPageTitle.feature
+++ b/UI/Features/BlazedemoPageTitle.feature
@@ -1,0 +1,9 @@
+@UI @Regression @Blazedemo
+Feature: Blazedemo Page Title Verification
+  As a user
+  I want to verify the page title of Blazedemo
+  So that I can ensure I'm on the correct website
+
+Scenario: Verify Blazedemo page title
+  Given I navigate to the Blazedemo website
+  Then the page title should be "BlazeDemo"

--- a/UI/StepDefinitions/BlazedemoPageTitleSteps.cs
+++ b/UI/StepDefinitions/BlazedemoPageTitleSteps.cs
@@ -1,0 +1,31 @@
+using AutomationFramework.Core.Base;
+using AutomationFramework.Core.Singleton;
+using NUnit.Framework;
+using OpenQA.Selenium;
+using TechTalk.SpecFlow;
+
+namespace AutomationFramework.UI.StepDefinitions
+{
+    [Binding]
+    public class BlazedemoPageTitleSteps : BasePage
+    {
+        private readonly IWebDriver _driver;
+
+        public BlazedemoPageTitleSteps(BrowserFactory browserFactory)
+        {
+            _driver = browserFactory.Driver;
+        }
+
+        [Given(@"I navigate to the Blazedemo website")]
+        public void GivenINavigateToTheBlazedemoWebsite()
+        {
+            _driver.Navigate().GoToUrl("https://blazedemo.com/");
+        }
+
+        [Then(@"the page title should be ""(.*)""")]
+        public void ThenThePageTitleShouldBe(string expectedTitle)
+        {
+            Assert.AreEqual(expectedTitle, _driver.Title, "Page title does not match the expected value.");
+        }
+    }
+}


### PR DESCRIPTION
This pull request adds the following changes:

1. New negative scenarios for the PetStore API delete operation:
   - Added a new feature file: API/Features/PetStoreDeleteNegative.feature
   - Added a new step definition file: API/StepDefinitions/PetStoreDeleteNegativeSteps.cs

2. New UI test for Blazedemo page title:
   - Added a new feature file: UI/Features/BlazedemoPageTitle.feature
   - Added a new step definition file: UI/StepDefinitions/BlazedemoPageTitleSteps.cs

These changes improve test coverage for the PetStore API and add a basic UI test for the Blazedemo website.