### PR TITLE
Add test to verify BlazeDemo page title

### DIFF
--- a/UI/Features/BlazeDemoTitle.feature
+++ b/UI/Features/BlazeDemoTitle.feature
@@ -1,0 +1,5 @@
+Feature: Verify BlazeDemo Page Title
+  @UI @Positive
+  Scenario: Verify the page title of BlazeDemo
+    Given I navigate to "https://blazedemo.com/"
+    Then the page title should be "BlazeDemo"

--- a/UI/StepDefinitions/BlazeDemoTitleSteps.cs
+++ b/UI/StepDefinitions/BlazeDemoTitleSteps.cs
@@ -1,0 +1,43 @@
+using OpenQA.Selenium;
+using TechTalk.SpecFlow;
+using EliteAOneInc.Core.Utilities;
+using EliteAOneInc.TestRunner.Hooks;
+
+namespace EliteAOneInc.UI.StepDefinitions
+{
+    [Binding]
+    public class BlazeDemoTitleSteps
+    {
+        private readonly IWebDriver _driver;
+
+        public BlazeDemoTitleSteps(IWebDriver driver)
+        {
+            _driver = driver;
+        }
+
+        [Given(@"I navigate to "(.*)"")]
+        public void GivenINavigateTo(string url)
+        {
+            _driver.Navigate().GoToUrl(url);
+        }
+
+        [Then(@"the page title should be "(.*)"")]
+        public void ThenThePageTitleShouldBe(string expectedTitle)
+        {
+            try
+            {
+                string actualTitle = _driver.Title;
+                if (actualTitle != expectedTitle)
+                {
+                    ScreenshotHelper.TakeScreenshot(_driver, "BlazeDemoTitleValidationFailure");
+                }
+                Assert.AreEqual(expectedTitle, actualTitle);
+            }
+            catch (Exception ex)
+            {
+                ScreenshotHelper.TakeScreenshot(_driver, "BlazeDemoTitleException");
+                throw new Exception($"An error occurred while validating the page title: {ex.Message}");
+            }
+        }
+    }
+}


### PR DESCRIPTION
This PR adds a new UI test to verify the page title of BlazeDemo.

- Added a new feature file `BlazeDemoTitle.feature` under `UI/Features/`.
- Added corresponding step definitions in `BlazeDemoTitleSteps.cs` under `UI/StepDefinitions/`.

closes #1