### PR TITLE
Add test to verify page title of Blazedemo

### DIFF
--- a/UI/Features/VerifyPageTitle.feature
+++ b/UI/Features/VerifyPageTitle.feature
@@ -1,0 +1,4 @@
+Feature: Verify Page Title
+  Scenario: Verify the page title of Blazedemo
+    Given I navigate to "https://blazedemo.com/"
+    Then the page title should be "BlazeDemo"

--- a/UI/StepDefinitions/VerifyPageTitleSteps.cs
+++ b/UI/StepDefinitions/VerifyPageTitleSteps.cs
@@ -1,0 +1,42 @@
+using OpenQA.Selenium;
+using NUnit.Framework;
+using TechTalk.SpecFlow;
+using AutomationFramework.Core.Utilities;
+
+namespace AutomationFramework.UI.StepDefinitions
+{
+    [Binding]
+    public class VerifyPageTitleSteps
+    {
+        private readonly ScenarioContext _scenarioContext;
+        private IWebDriver _driver;
+
+        public VerifyPageTitleSteps(ScenarioContext scenarioContext)
+        {
+            _scenarioContext = scenarioContext;
+        }
+
+        [Given(@"I navigate to ""(.*)""")]
+        public void GivenINavigateTo(string url)
+        {
+            _driver = (IWebDriver)_scenarioContext["WebDriver"];
+            _driver.Navigate().GoToUrl(url);
+        }
+
+        [Then(@"the page title should be ""(.*)""")]
+        public void ThenThePageTitleShouldBe(string expectedTitle)
+        {
+            _driver = (IWebDriver)_scenarioContext["WebDriver"];
+            try
+            {
+                string actualTitle = _driver.Title;
+                Assert.AreEqual(expectedTitle, actualTitle, $"Expected title to be '{expectedTitle}' but was '{actualTitle}'");
+            }
+            catch (Exception ex)
+            {
+                ScreenshotHelper.CaptureScreenshot(_driver, _scenarioContext.ScenarioInfo.Title);
+                Assert.Fail($"Error verifying page title: {ex.Message}");
+            }
+        }
+    }
+}


### PR DESCRIPTION
This pull request adds a new test to verify the page title of https://blazedemo.com/. The test navigates to the URL and checks if the page title matches the expected title "BlazeDemo".