### PR TITLE
Add test to verify page title of BlazeDemo

### DIFF
--- a/UI/Features/VerifyPageTitle.feature
+++ b/UI/Features/VerifyPageTitle.feature
@@ -1,0 +1,8 @@
+@UI @Positive
+Feature: Verify Page Title
+  As a user
+  I want to verify the page title of the BlazeDemo website
+
+  Scenario: Verify BlazeDemo page title
+    Given I navigate to "https://blazedemo.com/"
+    Then the title should be "BlazeDemo"

--- a/UI/StepDefinitions/VerifyPageTitleSteps.cs
+++ b/UI/StepDefinitions/VerifyPageTitleSteps.cs
@@ -1,0 +1,41 @@
+using OpenQA.Selenium;
+using NUnit.Framework;
+using TechTalk.SpecFlow;
+using AutomationFramework.Core.Utilities;
+
+namespace AutomationFramework.UI.StepDefinitions
+{
+    [Binding]
+    public class VerifyPageTitleSteps
+    {
+        private readonly ScenarioContext _scenarioContext;
+        private IWebDriver _driver;
+
+        public VerifyPageTitleSteps(ScenarioContext scenarioContext)
+        {
+            _scenarioContext = scenarioContext;
+        }
+
+        [Given(@"I navigate to "(.*)"")]
+        public void GivenINavigateTo(string url)
+        {
+            _driver = (IWebDriver)_scenarioContext["WebDriver"];
+            _driver.Navigate().GoToUrl(url);
+        }
+
+        [Then(@"the title should be "(.*)"")]
+        public void ThenTheTitleShouldBe(string expectedTitle)
+        {
+            try
+            {
+                string actualTitle = _driver.Title;
+                Assert.That(actualTitle, Is.EqualTo(expectedTitle), "Expected page title does not match the actual title.");
+            }
+            catch (Exception ex)
+            {
+                ScreenshotHelper.CaptureScreenshot(_driver, "VerifyPageTitle");
+                throw new Exception("Validation failed: " + ex.Message);
+            }
+        }
+    }
+}


### PR DESCRIPTION
This PR adds a new test to verify the page title of the BlazeDemo website.

- Added feature file `VerifyPageTitle.feature`
- Added step definitions in `VerifyPageTitleSteps.cs`

Closes #1