### PR TITLE
Add UI test to verify BlazeDemo page title – Ref: 1234

### DIFF
--- a/UI/Features/VerifyBlazeDemoTitle.feature
+++ b/UI/Features/VerifyBlazeDemoTitle.feature
@@ -1,0 +1,5 @@
+Feature: Verify BlazeDemo Page Title
+  @UI @Positive
+  Scenario: Verify the page title of BlazeDemo homepage
+    Given I navigate to "https://blazedemo.com/"
+    Then the page title should be "BlazeDemo"

--- a/UI/StepDefinitions/VerifyBlazeDemoTitleSteps.cs
+++ b/UI/StepDefinitions/VerifyBlazeDemoTitleSteps.cs
@@ -1,0 +1,41 @@
+using OpenQA.Selenium;
+using NUnit.Framework;
+using TechTalk.SpecFlow;
+using AutomationFramework.Core.Utilities;
+
+namespace UI.StepDefinitions
+{
+    [Binding]
+    public class VerifyBlazeDemoTitleSteps
+    {
+        private readonly IWebDriver _driver;
+        private readonly ScenarioContext _scenarioContext;
+
+        public VerifyBlazeDemoTitleSteps(ScenarioContext scenarioContext)
+        {
+            _scenarioContext = scenarioContext;
+            _driver = (IWebDriver)_scenarioContext["WebDriver"];
+        }
+
+        [Given(@"I navigate to \"(.*)\"")]
+        public void GivenINavigateTo(string url)
+        {
+            _driver.Navigate().GoToUrl(url);
+        }
+
+        [Then(@"the page title should be \"(.*)\"")]
+        public void ThenThePageTitleShouldBe(string expectedTitle)
+        {
+            try
+            {
+                string actualTitle = _driver.Title;
+                Assert.That(actualTitle, Is.EqualTo(expectedTitle), $"Expected {{expectedTitle}} but found {{actualTitle}}");
+            }
+            catch (Exception ex)
+            {
+                ScreenshotHelper.CaptureScreenshot(_driver, _scenarioContext.ScenarioInfo.Title);
+                throw new Exception($"Assertion failed: {{ex.Message}}");
+            }
+        }
+    }
+}


### PR DESCRIPTION
This pull request includes a new UI test to verify the page title of the BlazeDemo homepage.

- Added a feature file `VerifyBlazeDemoTitle.feature` with a scenario to navigate to the BlazeDemo homepage and verify its title.
- Added a step definition file `VerifyBlazeDemoTitleSteps.cs` to implement the steps defined in the feature file.

The test navigates to `https://blazedemo.com/` and asserts that the page title is `BlazeDemo`. If the assertion fails, a screenshot is captured and saved using the `ScreenshotHelper` utility.