### PR TITLE
Add UI test to verify BlazeDemo page title – Ref: 5678

### DIFF
--- a/UI/Features/VerifyBlazeDemoTitle.feature
+++ b/UI/Features/VerifyBlazeDemoTitle.feature
@@ -1,0 +1,5 @@
+Feature: Verify BlazeDemo Page Title
+  @UI @Positive
+  Scenario: Verify the page title of BlazeDemo
+    Given I navigate to 'https://blazedemo.com/'
+    Then the page title should be 'BlazeDemo'

--- a/UI/StepDefinitions/VerifyBlazeDemoTitleSteps.cs
+++ b/UI/StepDefinitions/VerifyBlazeDemoTitleSteps.cs
@@ -1,0 +1,41 @@
+using OpenQA.Selenium;
+using NUnit.Framework;
+using TechTalk.SpecFlow;
+using AutomationFramework.Core.Utilities;
+
+namespace UI.StepDefinitions
+{
+    [Binding]
+    public class VerifyBlazeDemoTitleSteps
+    {
+        private readonly ScenarioContext _scenarioContext;
+        private readonly IWebDriver _driver;
+
+        public VerifyBlazeDemoTitleSteps(ScenarioContext scenarioContext)
+        {
+            _scenarioContext = scenarioContext;
+            _driver = (IWebDriver)_scenarioContext["WebDriver"];
+        }
+
+        [Given(@"I navigate to '(.*)'")]
+        public void GivenINavigateTo(string url)
+        {
+            _driver.Navigate().GoToUrl(url);
+        }
+
+        [Then(@"the page title should be '(.*)'")]
+        public void ThenThePageTitleShouldBe(string expectedTitle)
+        {
+            try
+            {
+                string actualTitle = _driver.Title;
+                Assert.That(actualTitle, Is.EqualTo(expectedTitle), $"Expected {expectedTitle} but found {actualTitle}");
+            }
+            catch (Exception ex)
+            {
+                ScreenshotHelper.CaptureScreenshot(_driver, "VerifyBlazeDemoTitle");
+                throw new Exception($"Assertion failed: {ex.Message}", ex);
+            }
+        }
+    }
+}


### PR DESCRIPTION
This pull request adds a new UI test to verify the page title of BlazeDemo.

Feature file and step definitions have been created as per the requirements.

closes #5678