### PR TITLE
Add UI test to verify BlazeDemo page title – Ref: 8912

### DIFF
--- a/UI/Features/VerifyBlazeDemoTitle.feature
+++ b/UI/Features/VerifyBlazeDemoTitle.feature
@@ -1,0 +1,19 @@
+@UI @Positive
+Feature: Verify BlazeDemo Page Title
+  As a user
+  I want to verify the page title of BlazeDemo
+  So that I can ensure the website is loaded correctly
+
+  Scenario: Verify the page title is correct
+    Given I navigate to 'https://blazedemo.com/'
+    Then the page title should be 'BlazeDemo'
+
+@UI @Negative
+Feature: Verify BlazeDemo Page Title
+  As a user
+  I want to verify the page title of BlazeDemo
+  So that I can ensure the website is loaded correctly
+
+  Scenario: Verify the page title is incorrect
+    Given I navigate to 'https://blazedemo.com/'
+    Then the page title should not be 'IncorrectTitle'

--- a/UI/StepDefinitions/VerifyBlazeDemoTitleSteps.cs
+++ b/UI/StepDefinitions/VerifyBlazeDemoTitleSteps.cs
@@ -1,0 +1,56 @@
+using OpenQA.Selenium;
+using NUnit.Framework;
+using TechTalk.SpecFlow;
+using AutomationFramework.Core.Utilities;
+
+namespace UI.StepDefinitions
+{
+    [Binding]
+    public class VerifyBlazeDemoTitleSteps
+    {
+        private readonly ScenarioContext _scenarioContext;
+        private readonly IWebDriver _driver;
+
+        public VerifyBlazeDemoTitleSteps(ScenarioContext scenarioContext)
+        {
+            _scenarioContext = scenarioContext;
+            _driver = (IWebDriver)_scenarioContext["WebDriver"];
+        }
+
+        [Given(@'I navigate to "(.*)"')]
+        public void GivenINavigateTo(string url)
+        {
+            _driver.Navigate().GoToUrl(url);
+        }
+
+        [Then(@'the page title should be "(.*)"')]
+        public void ThenThePageTitleShouldBe(string expectedTitle)
+        {
+            try
+            {
+                string actualTitle = _driver.Title;
+                Assert.That(actualTitle, Is.EqualTo(expectedTitle), $"Expected '{expectedTitle}' but found '{actualTitle}'");
+            }
+            catch (Exception ex)
+            {
+                ScreenshotHelper.CaptureScreenshot(_driver, "VerifyBlazeDemoTitle");
+                throw new Exception($"Assertion failed: {ex.Message}");
+            }
+        }
+
+        [Then(@'the page title should not be "(.*)"')]
+        public void ThenThePageTitleShouldNotBe(string unexpectedTitle)
+        {
+            try
+            {
+                string actualTitle = _driver.Title;
+                Assert.That(actualTitle, Is.Not.EqualTo(unexpectedTitle), $"Expected title not to be '{unexpectedTitle}' but found '{actualTitle}'");
+            }
+            catch (Exception ex)
+            {
+                ScreenshotHelper.CaptureScreenshot(_driver, "VerifyBlazeDemoTitle");
+                throw new Exception($"Assertion failed: {ex.Message}");
+            }
+        }
+    }
+}


### PR DESCRIPTION
This PR adds positive and negative tests to verify the page title for https://blazedemo.com/.

The following changes were made:
- Created feature file `VerifyBlazeDemoTitle.feature` with positive and negative scenarios.
- Created step definition file `VerifyBlazeDemoTitleSteps.cs` to implement the steps.

closes #8912