### PR TITLE
Add UI test to verify BlazeDemo page title – Ref: 4821

### DIFF
--- a/UI/Features/VerifyBlazeDemoTitle.feature
+++ b/UI/Features/VerifyBlazeDemoTitle.feature
@@ -1,0 +1,11 @@
+@UI @Positive
+Feature: Verify BlazeDemo Page Title
+  Scenario: Verify the page title is correct
+    Given I navigate to 'https://blazedemo.com/'
+    Then the page title should be 'BlazeDemo'
+
+@UI @Negative
+Feature: Verify BlazeDemo Page Title
+  Scenario: Verify the page title is incorrect
+    Given I navigate to 'https://blazedemo.com/'
+    Then the page title should not be 'IncorrectTitle'

--- a/UI/StepDefinitions/VerifyBlazeDemoTitleSteps.cs
+++ b/UI/StepDefinitions/VerifyBlazeDemoTitleSteps.cs
@@ -1,0 +1,56 @@
+using OpenQA.Selenium;
+using NUnit.Framework;
+using TechTalk.SpecFlow;
+using AutomationFramework.Core.Utilities;
+
+namespace AutomationFramework.UI.StepDefinitions
+{
+    [Binding]
+    public class VerifyBlazeDemoTitleSteps
+    {
+        private readonly ScenarioContext _scenarioContext;
+        private readonly IWebDriver _driver;
+
+        public VerifyBlazeDemoTitleSteps(ScenarioContext scenarioContext)
+        {
+            _scenarioContext = scenarioContext;
+            _driver = (IWebDriver)_scenarioContext["WebDriver"];
+        }
+
+        [Given(@"I navigate to '(.*)'")]
+        public void GivenINavigateTo(string url)
+        {
+            _driver.Navigate().GoToUrl(url);
+        }
+
+        [Then(@"the page title should be '(.*)'")]
+        public void ThenThePageTitleShouldBe(string expectedTitle)
+        {
+            try
+            {
+                string actualTitle = _driver.Title;
+                Assert.That(actualTitle, Is.EqualTo(expectedTitle), $"Expected '{expectedTitle}' but found '{actualTitle}'");
+            }
+            catch (Exception ex)
+            {
+                ScreenshotHelper.CaptureScreenshot(_driver, "VerifyBlazeDemoTitle");
+                throw new Exception($"Assertion failed: {ex.Message}");
+            }
+        }
+
+        [Then(@"the page title should not be '(.*)'")]
+        public void ThenThePageTitleShouldNotBe(string expectedTitle)
+        {
+            try
+            {
+                string actualTitle = _driver.Title;
+                Assert.That(actualTitle, Is.Not.EqualTo(expectedTitle), $"Expected title not to be '{expectedTitle}' but it was.");
+            }
+            catch (Exception ex)
+            {
+                ScreenshotHelper.CaptureScreenshot(_driver, "VerifyBlazeDemoTitle");
+                throw new Exception($"Assertion failed: {ex.Message}");
+            }
+        }
+    }
+}


### PR DESCRIPTION
This pull request includes positive and negative tests to verify the page title for https://blazedemo.com/.

- Positive test: Verifies that the page title is 'BlazeDemo'.
- Negative test: Verifies that the page title is not 'IncorrectTitle'.

Both tests include proper assertions and screenshot capture on failure.