### PR TITLE
Add API test for PetStore negative scenarios

### DIFF
--- a/API/Features/PetStoreNegative.feature
+++ b/API/Features/PetStoreNegative.feature
@@ -1,0 +1,53 @@
+@PetStoreAPI @Regression @APITesting
+Feature: Pet Store API Negative Operations
+  As an API consumer
+  I want to handle errors when performing CRUD operations on pets
+  So that I can ensure the API handles invalid inputs gracefully
+
+Background:
+  Given the PetStore API is available and accessible
+
+@CreatePet @NegativeScenario
+Scenario Outline: Fail to create a new pet with invalid data
+  Given I have a pet creation payload with following details
+    | Name      | Status      | Category | Tags      |
+    | <PetName> | <PetStatus> | <Breed>  | <PetTags> |
+  When I send a POST request to create the pet
+  Then the response status code should not be 200
+  And the pet should not be created
+
+Examples:
+  | PetName  | PetStatus | Breed | PetTags  |
+  |          | available | Dog   | Friendly |
+  | Whiskers |           | Cat   | Playful  |
+  | Rex      | sold      |       | Guardian |
+
+@RetrievePet @NegativeScenario
+Scenario: Fail to retrieve a pet by invalid ID
+  Given I have an invalid pet ID
+  When I retrieve the pet by ID
+  Then the response status code should not be 200
+  And the pet details should not be returned
+
+@UpdatePet @NegativeScenario
+Scenario Outline: Fail to update a pet with invalid details
+  Given I have successfully created a pet with the following details
+    | Name      | Status      | Category | Tags   |
+    | <OldName> | <OldStatus> | <Breed>  | <Tags> |
+  When I update the pet with generated ID with invalid details
+    | Name      | Status      | Category | Tags   |
+    | <NewName> | <NewStatus> | <Breed>  | <Tags> |
+  Then the response status code should not be 200
+  And the pet should not be updated
+
+Examples:
+  | OldName | OldStatus | NewName  | NewStatus | Breed | Tags    | PetID |
+  | Max     | available |          | sold      | Dog   | Guard   | 1234  |
+  | Kitty   | pending   | Princess |           | Cat   | Playful | 5678  |
+
+@DeletePet @NegativeScenario
+Scenario: Fail to delete a pet by invalid ID
+  Given I have an invalid pet ID
+  When I delete the pet with generated ID
+  Then the response status code should not be 200
+  And the pet should not be deleted

--- a/API/StepDefinitions/PetStoreNegativeSteps.cs
+++ b/API/StepDefinitions/PetStoreNegativeSteps.cs
@@ -1,0 +1,139 @@
+using NUnit.Framework;
+using TechTalk.SpecFlow;
+using EliteAOneInc.API.Clients;
+using EliteAOneInc.API.BusinessLogic;
+using EliteAOneInc.API.Builders;
+
+namespace EliteAOneInc.API.StepDefinitions
+{
+    [Binding]
+    public class PetStoreNegativeSteps
+    {
+        private readonly PetStoreApiClient _apiClient;
+        private readonly PetBusinessLogic _businessLogic;
+        private readonly ScenarioContext _scenarioContext;
+
+        public PetStoreNegativeSteps(PetStoreApiClient apiClient, PetBusinessLogic businessLogic, ScenarioContext scenarioContext)
+        {
+            _apiClient = apiClient;
+            _businessLogic = businessLogic;
+            _scenarioContext = scenarioContext;
+        }
+
+        [Given(@"I have a pet creation payload with following details")]
+        public void GivenIHaveAPetCreationPayloadWithFollowingDetails(Table table)
+        {
+            var pet = PetBuilder.BuildPetFromTable(table);
+            _scenarioContext["PetPayload"] = pet;
+        }
+
+        [When(@"I send a POST request to create the pet")]
+        public void WhenISendAPostRequestToCreateThePet()
+        {
+            var pet = _scenarioContext["PetPayload"] as Pet;
+            var response = _apiClient.CreatePet(pet);
+            _scenarioContext["Response"] = response;
+        }
+
+        [Then(@"the response status code should not be 200")]
+        public void ThenTheResponseStatusCodeShouldNotBe200()
+        {
+            var response = _scenarioContext["Response"] as ApiResponse;
+            try
+            {
+                Assert.That(response.StatusCode, Is.Not.EqualTo(200), "Expected status code to not be 200");
+            }
+            catch (AssertionException ex)
+            {
+                throw new AssertionException($"Assertion failed: {ex.Message}");
+            }
+        }
+
+        [Then(@"the pet should not be created")]
+        public void ThenThePetShouldNotBeCreated()
+        {
+            var response = _scenarioContext["Response"] as ApiResponse;
+            try
+            {
+                Assert.That(response.IsSuccessStatusCode, Is.False, "Expected pet creation to fail");
+            }
+            catch (AssertionException ex)
+            {
+                throw new AssertionException($"Assertion failed: {ex.Message}");
+            }
+        }
+
+        [Given(@"I have an invalid pet ID")]
+        public void GivenIHaveAnInvalidPetID()
+        {
+            _scenarioContext["PetID"] = "invalid-id";
+        }
+
+        [When(@"I retrieve the pet by ID")]
+        public void WhenIRetrieveThePetByID()
+        {
+            var petId = _scenarioContext["PetID"] as string;
+            var response = _apiClient.GetPetById(petId);
+            _scenarioContext["Response"] = response;
+        }
+
+        [Then(@"the pet details should not be returned")]
+        public void ThenThePetDetailsShouldNotBeReturned()
+        {
+            var response = _scenarioContext["Response"] as ApiResponse;
+            try
+            {
+                Assert.That(response.IsSuccessStatusCode, Is.False, "Expected pet retrieval to fail");
+            }
+            catch (AssertionException ex)
+            {
+                throw new AssertionException($"Assertion failed: {ex.Message}");
+            }
+        }
+
+        [When(@"I update the pet with generated ID with invalid details")]
+        public void WhenIUpdateThePetWithGeneratedIDWithInvalidDetails(Table table)
+        {
+            var petId = _scenarioContext["PetID"] as string;
+            var pet = PetBuilder.BuildPetFromTable(table);
+            var response = _apiClient.UpdatePet(petId, pet);
+            _scenarioContext["Response"] = response;
+        }
+
+        [Then(@"the pet should not be updated")]
+        public void ThenThePetShouldNotBeUpdated()
+        {
+            var response = _scenarioContext["Response"] as ApiResponse;
+            try
+            {
+                Assert.That(response.IsSuccessStatusCode, Is.False, "Expected pet update to fail");
+            }
+            catch (AssertionException ex)
+            {
+                throw new AssertionException($"Assertion failed: {ex.Message}");
+            }
+        }
+
+        [When(@"I delete the pet with generated ID")]
+        public void WhenIDeleteThePetWithGeneratedID()
+        {
+            var petId = _scenarioContext["PetID"] as string;
+            var response = _apiClient.DeletePet(petId);
+            _scenarioContext["Response"] = response;
+        }
+
+        [Then(@"the pet should not be deleted")]
+        public void ThenThePetShouldNotBeDeleted()
+        {
+            var response = _scenarioContext["Response"] as ApiResponse;
+            try
+            {
+                Assert.That(response.IsSuccessStatusCode, Is.False, "Expected pet deletion to fail");
+            }
+            catch (AssertionException ex)
+            {
+                throw new AssertionException($"Assertion failed: {ex.Message}");
+            }
+        }
+    }
+}


### PR DESCRIPTION
This PR adds a new feature file `PetStoreNegative.feature` containing negative test scenarios for the PetStore API. It also includes the corresponding step definition file `PetStoreNegativeSteps.cs`.

The negative scenarios cover the following cases:
- Fail to create a new pet with invalid data
- Fail to retrieve a pet by invalid ID
- Fail to update a pet with invalid details
- Fail to delete a pet by invalid ID

These tests ensure that the API handles invalid inputs gracefully and returns appropriate error responses.