### PR TITLE
Add Negative Test Scenarios for Pet Store API

### DIFF
--- a/API/Features/PetStoreNegative.feature
+++ b/API/Features/PetStoreNegative.feature
@@ -1,0 +1,51 @@
+@PetStoreAPI @Regression @APITesting
+Feature: Pet Store API Negative Operations
+  As an API consumer
+  I want to test failure conditions for CRUD operations on pets
+  So that I can ensure the API handles errors gracefully
+
+Background:
+  Given the PetStore API is available and accessible
+
+@CreatePet @NegativeScenario
+Scenario Outline: Fail to create a new pet with invalid data
+  Given I have a pet creation payload with following invalid details
+    | Name      | Status      | Category | Tags      |
+    | <PetName> | <PetStatus> | <Breed>  | <PetTags> |
+  When I send a POST request to create the pet
+  Then the response status code should be 400
+  And the pet should not be created
+
+Examples:
+  | PetName  | PetStatus | Breed | PetTags  |
+  |          | available | Dog   | Friendly |
+  | Buddy    |           | Cat   | Playful  |
+  | Rex      | sold      |       | Guardian |
+
+@RetrievePet @NegativeScenario
+Scenario: Fail to retrieve a non-existing pet by invalid ID
+  Given I have an invalid pet ID
+  When I retrieve the pet by ID
+  Then the response status code should be 404
+  And the pet details should not be returned
+
+@UpdatePet @NegativeScenario
+Scenario Outline: Fail to update a non-existing pet with new details
+  Given I have an invalid pet ID
+  When I update the pet with invalid ID with new details
+    | Name      | Status      | Category | Tags   |
+    | <NewName> | <NewStatus> | <Breed>  | <Tags> |
+  Then the response status code should be 404
+  And the pet should not be updated
+
+Examples:
+  | NewName  | NewStatus | Breed | Tags    |
+  | Maximus  | sold      | Dog   | Guard   |
+  | Princess | available | Cat   | Playful |
+
+@DeletePet @NegativeScenario
+Scenario: Fail to delete a non-existing pet by invalid ID
+  Given I have an invalid pet ID
+  When I delete the pet with invalid ID
+  Then the response status code should be 404
+  And the pet should not be deleted

--- a/API/StepDefinitions/PetStoreNegativeSteps.cs
+++ b/API/StepDefinitions/PetStoreNegativeSteps.cs
@@ -1,0 +1,119 @@
+using BoDi;
+using TechTalk.SpecFlow;
+using AutomationFramework.API.BusinessLogic;
+using AutomationFramework.Core.Config;
+using RestSharp;
+using FluentAssertions;
+using Serilog;
+
+namespace AutomationFramework.API.StepDefinitions
+{
+    [Binding]
+    public class PetStoreNegativeSteps
+    {
+        private readonly PetBusinessLogic _petBusinessLogic;
+        private RestResponse _response;
+        private long _invalidPetId = -1; // Invalid pet ID for negative scenarios
+        private ScenarioContext _scenarioContext;
+        private string PetId = "PetID";
+
+        public PetStoreNegativeSteps(ScenarioContext scenarioContext)
+        {
+            var baseUrl = ConfigManager.GetConfigValue<string>("ApiBaseUrl");
+            _scenarioContext = scenarioContext;
+            _petBusinessLogic = new PetBusinessLogic(baseUrl);
+        }
+
+        [Given(@"the PetStore API is available and accessible")]
+        public void GivenThePetStoreAPIIsAvailableAndAccessible()
+        {
+            Log.Information("Verified that PetStore API is available.");
+        }
+
+        [Given(@"I have a pet creation payload with following invalid details")]
+        public void GivenIHaveAPetCreationPayloadWithFollowingInvalidDetails(Table table)
+        {
+            var row = table.Rows[0];
+            var name = row["Name"];
+            var status = row["Status"];
+            var category = row["Category"];
+            var tags = row["Tags"];
+
+            _response = _petBusinessLogic.CreatePet(name, status, category, tags);
+        }
+
+        [When(@"I send a POST request to create the pet")]
+        public void WhenISendAPostRequestToCreateThePet()
+        {
+            _response.Should().NotBeNull("Response from Create Pet API should not be null");
+            Log.Information("POST request sent to create a pet with provided payload.");
+        }
+
+        [Then(@"the response status code should be (.*)")]
+        public void ThenTheResponseStatusCodeShouldBe(int expectedStatusCode)
+        {
+            _response.StatusCode.Should().Be((System.Net.HttpStatusCode)expectedStatusCode);
+            Log.Information($"Verified response status code: {_response.StatusCode}");
+        }
+
+        [Then(@"the pet should not be created")]
+        public void ThenThePetShouldNotBeCreated()
+        {
+            _response.Content.Should().NotContain("\"id\":", "The response should not contain the 'id' of the created pet.");
+            Log.Information($"Pet creation failed as expected. Response content: {_response.Content}");
+        }
+
+        [Given(@"I have an invalid pet ID")]
+        public void GivenIHaveAnInvalidPetID()
+        {
+            ScenarioContextHelper.SetOrReplace(_scenarioContext, PetId, _invalidPetId);
+        }
+
+        [When(@"I retrieve the pet by ID")]
+        public void WhenIRetrieveThePetByID()
+        {
+            var petId = _scenarioContext.Get<long>(PetId);
+            _response = _petBusinessLogic.GetPetById(petId);
+        }
+
+        [Then(@"the pet details should not be returned")]
+        public void ThenThePetDetailsShouldNotBeReturned()
+        {
+            _response.StatusCode.Should().Be(System.Net.HttpStatusCode.NotFound);
+            Log.Information("Pet details retrieval failed as expected. Response content: {Content}", _response.Content);
+        }
+
+        [When(@"I update the pet with invalid ID with new details")]
+        public void WhenIUpdateThePetWithInvalidIDWithNewDetails(Table table)
+        {
+            var row = table.Rows[0];
+            var name = row["Name"];
+            var status = row["Status"];
+            var category = row["Category"];
+            var tags = row["Tags"];
+            var petId = _scenarioContext.Get<long>(PetId);
+            _response = _petBusinessLogic.UpdatePet(petId, name, status, category, tags);
+        }
+
+        [Then(@"the pet should not be updated")]
+        public void ThenThePetShouldNotBeUpdated()
+        {
+            _response.StatusCode.Should().Be(System.Net.HttpStatusCode.NotFound);
+            Log.Information("Pet update failed as expected. Response content: {Content}");
+        }
+
+        [When(@"I delete the pet with invalid ID")]
+        public void WhenIDeleteThePetWithInvalidID()
+        {
+            var petId = _scenarioContext.Get<long>(PetId);
+            _response = _petBusinessLogic.DeletePet(petId);
+        }
+
+        [Then(@"the pet should not be deleted")]
+        public void ThenThePetShouldNotBeDeleted()
+        {
+            _response.StatusCode.Should().Be(System.Net.HttpStatusCode.NotFound);
+            Log.Information("Pet deletion failed as expected.");
+        }
+    }
+}


### PR DESCRIPTION
This PR adds negative test scenarios for the Pet Store API to ensure that the API handles error conditions gracefully. The following changes are included:

- New feature file `PetStoreNegative.feature` with negative test scenarios for create, retrieve, update, and delete operations.
- New step definitions file `PetStoreNegativeSteps.cs` to implement the negative test scenarios.

These tests cover cases such as invalid data for pet creation, non-existing pet ID for retrieval, update, and deletion operations.