### PR TITLE
Add Negative Test Scenarios for Pet Store API

### DIFF
--- a/API/Features/PetStoreNegative.feature
+++ b/API/Features/PetStoreNegative.feature
@@ -1,0 +1,51 @@
+@PetStoreAPI @Regression @APITesting
+Feature: Pet Store API Negative Operations
+  As an API consumer
+  I want to handle errors gracefully when performing CRUD operations on pets
+  So that I can ensure robustness of the API
+
+Background:
+  Given the PetStore API is available and accessible
+
+@Smoke @CreatePet @NegativeScenario
+Scenario Outline: Fail to create a new pet with invalid data
+  Given I have a pet creation payload with invalid details
+    | Name      | Status      | Category | Tags      |
+    | <PetName> | <PetStatus> | <Breed>  | <PetTags> |
+  When I send a POST request to create the pet
+  Then the response status code should be 400
+  And the pet should not be created
+
+Examples:
+  | PetName  | PetStatus | Breed | PetTags  |
+  |          | available | Dog   | Friendly |
+  | Whiskers |           | Cat   | Playful  |
+  | Rex      | sold      |       | Guardian |
+
+@RetrievePet @NegativeScenario
+Scenario: Fail to retrieve a pet by invalid ID
+  Given I have an invalid pet ID
+  When I retrieve the pet by ID
+  Then the response status code should be 404
+  And the pet details should not be returned
+
+@UpdatePet @NegativeScenario
+Scenario Outline: Fail to update a non-existing pet
+  Given I have a non-existing pet ID
+  When I update the pet with generated ID with new details
+    | Name      | Status      | Category | Tags   |
+    | <NewName> | <NewStatus> | <Breed>  | <Tags> |
+  Then the response status code should be 404
+  And the pet should not be updated
+
+Examples:
+  | NewName  | NewStatus | Breed | Tags    |
+  | Maximus  | sold      | Dog   | Guard   |
+  | Princess | available | Cat   | Playful |
+
+@DeletePet @NegativeScenario
+Scenario: Fail to delete a non-existing pet by invalid ID
+  Given I have a non-existing pet ID
+  When I delete the pet with generated ID
+  Then the response status code should be 404
+  And the pet should not be deleted

--- a/API/StepDefinitions/PetStoreNegativeSteps.cs
+++ b/API/StepDefinitions/PetStoreNegativeSteps.cs
@@ -1,0 +1,86 @@
+using BoDi;
+using TechTalk.SpecFlow;
+using AutomationFramework.API.BusinessLogic;
+using AutomationFramework.Core.Config;
+using RestSharp;
+using FluentAssertions;
+using Serilog;
+
+namespace AutomationFramework.API.StepDefinitions
+{
+    [Binding]
+    public class PetStoreNegativeSteps
+    {
+        private readonly PetBusinessLogic _petBusinessLogic;
+        private RestResponse _response;
+        private long _petId;
+        private ScenarioContext _scenarioContext;
+        private string PetId = "PetID";
+        public PetStoreNegativeSteps(ScenarioContext scenarioContext)
+        {
+            var baseUrl = ConfigManager.GetConfigValue<string>("ApiBaseUrl");
+            _scenarioContext = scenarioContext;
+            _petBusinessLogic = new PetBusinessLogic(baseUrl);
+        }
+
+        [Given(@"the PetStore API is available and accessible")]
+        public void GivenThePetStoreAPIIsAvailableAndAccessible()
+        {
+            Log.Information("Verified that PetStore API is available.");
+        }
+
+        [Given(@"I have a pet creation payload with invalid details")]
+        public void GivenIHaveAPetCreationPayloadWithInvalidDetails(Table table)
+        {
+            var row = table.Rows[0];
+            var name = row["Name"];
+            var status = row["Status"];
+            var category = row["Category"];
+            var tags = row["Tags"];
+
+            _response = _petBusinessLogic.CreatePet(name, status, category, tags);
+        }
+
+        [Then(@"the pet should not be created")]
+        public void ThenThePetShouldNotBeCreated()
+        {
+            _response.Content.Should().NotContain("\"id\":", "The response should not contain the 'id' of the created pet.");
+            Log.Information($"Pet creation failed as expected. Response content: {_response.Content}");
+        }
+
+        [Given(@"I have an invalid pet ID")]
+        public void GivenIHaveAnInvalidPetID()
+        {
+            _petId = -1; // Invalid ID
+            ScenarioContextHelper.SetOrReplace(_scenarioContext, PetId, _petId);
+        }
+
+        [Then(@"the pet details should not be returned")]
+        public void ThenThePetDetailsShouldNotBeReturned()
+        {
+            _response.StatusCode.Should().Be(System.Net.HttpStatusCode.NotFound);
+            Log.Information("Pet details not found as expected. Response content: {Content}", _response.Content);
+        }
+
+        [Given(@"I have a non-existing pet ID")]
+        public void GivenIHaveANonExistingPetID()
+        {
+            _petId = 999999; // Non-existing ID
+            ScenarioContextHelper.SetOrReplace(_scenarioContext, PetId, _petId);
+        }
+
+        [Then(@"the pet should not be updated")]
+        public void ThenThePetShouldNotBeUpdated()
+        {
+            _response.StatusCode.Should().Be(System.Net.HttpStatusCode.NotFound);
+            Log.Information("Pet update failed as expected. Response content: {Content}");
+        }
+
+        [Then(@"the pet should not be deleted")]
+        public void ThenThePetShouldNotBeDeleted()
+        {
+            _response.StatusCode.Should().Be(System.Net.HttpStatusCode.NotFound);
+            Log.Information("Pet deletion failed as expected.");
+        }
+    }
+}


### PR DESCRIPTION
This PR adds negative test scenarios for the Pet Store API to ensure robustness and error handling.

- Added `PetStoreNegative.feature` with negative test scenarios.
- Added `PetStoreNegativeSteps.cs` with step definitions for the negative scenarios.

Each positive scenario now has a corresponding negative scenario to test invalid inputs and error conditions.