### PR TITLE
Add Negative Test for Pet Retrieval

### DIFF
--- a/API/Features/PetStoreNegative.feature
+++ b/API/Features/PetStoreNegative.feature
@@ -1,14 +1,15 @@
 @PetStoreAPI @NegativeScenario
 Feature: Pet Store API Negative Scenarios
   As an API consumer
-  I want to ensure the Pet Store API handles invalid scenarios gracefully
-  So that I can verify the robustness of the API
+  I want to handle errors gracefully
+  So that I can ensure robustness of the API
 
 Background:
-	Given the PetStore API is available and accessible
+  Given the PetStore API is available and accessible
 
 @RetrievePet @NegativeScenario
-Scenario: Retrieve a pet with invalid ID
-	When I retrieve a pet with an invalid ID
-	Then the response status code should be 404
-	And the response message should indicate that the pet was not found
+Scenario: Retrieve a non-existing pet by invalid ID
+  Given I have an invalid pet ID
+  When I retrieve the pet by invalid ID
+  Then the response status code should be 404 for invalid pet ID
+  And the error message should indicate pet not found

--- a/API/Features/PetStoreNegative.feature
+++ b/API/Features/PetStoreNegative.feature
@@ -1,0 +1,14 @@
+@PetStoreAPI @NegativeScenario
+Feature: Pet Store API Negative Scenarios
+  As an API consumer
+  I want to ensure the Pet Store API handles invalid scenarios gracefully
+  So that I can verify the robustness of the API
+
+Background:
+	Given the PetStore API is available and accessible
+
+@RetrievePet @NegativeScenario
+Scenario: Retrieve a pet with invalid ID
+	When I retrieve a pet with an invalid ID
+	Then the response status code should be 404
+	And the response message should indicate that the pet was not found

--- a/API/StepDefinitions/PetStoreNegativeSteps.cs
+++ b/API/StepDefinitions/PetStoreNegativeSteps.cs
@@ -13,6 +13,8 @@ namespace AutomationFramework.API.StepDefinitions
         private readonly PetBusinessLogic _petBusinessLogic;
         private RestResponse _response;
         private ScenarioContext _scenarioContext;
+        private const string InvalidPetIdKey = "InvalidPetID";
+
         public PetStoreNegativeSteps(ScenarioContext scenarioContext)
         {
             var baseUrl = ConfigManager.GetConfigValue<string>("ApiBaseUrl");
@@ -20,25 +22,33 @@ namespace AutomationFramework.API.StepDefinitions
             _petBusinessLogic = new PetBusinessLogic(baseUrl);
         }
 
-        [When(@"I retrieve a pet with an invalid ID")]
-        public void WhenIRetrieveAPetWithAnInvalidID()
+        [Given(@"I have an invalid pet ID")]
+        public void GivenIHaveAnInvalidPetID()
         {
-            var invalidPetId = -1; // Assuming -1 is an invalid ID
+            long invalidPetId = -1; // Assuming -1 is an invalid ID
+            ScenarioContextHelper.SetOrReplace(_scenarioContext, InvalidPetIdKey, invalidPetId);
+            Log.Information("Set an invalid pet ID for the test.");
+        }
+
+        [When(@"I retrieve the pet by invalid ID")]
+        public void WhenIRetrieveThePetByInvalidID()
+        {
+            var invalidPetId = _scenarioContext.Get<long>(InvalidPetIdKey);
             _response = _petBusinessLogic.GetPetById(invalidPetId);
         }
 
-        [Then(@"the response status code should be 404")]
-        public void ThenTheResponseStatusCodeShouldBe404()
+        [Then(@"the response status code should be 404 for invalid pet ID")]
+        public void ThenTheResponseStatusCodeShouldBe404ForInvalidPetID()
         {
             _response.StatusCode.Should().Be(System.Net.HttpStatusCode.NotFound);
-            Log.Information("Verified response status code: {StatusCode}", _response.StatusCode);
+            Log.Information("Verified response status code: 404 Not Found for invalid pet ID.");
         }
 
-        [Then(@"the response message should indicate that the pet was not found")]
-        public void ThenTheResponseMessageShouldIndicateThatThePetWasNotFound()
+        [Then(@"the error message should indicate pet not found")]
+        public void ThenTheErrorMessageShouldIndicatePetNotFound()
         {
-            _response.Content.Should().Contain("Pet not found");
-            Log.Information("Verified response message: {Content}", _response.Content);
+            _response.Content.Should().Contain("Pet not found", "The error message should indicate that the pet was not found.");
+            Log.Information("Verified error message indicates pet not found.");
         }
     }
 }

--- a/API/StepDefinitions/PetStoreNegativeSteps.cs
+++ b/API/StepDefinitions/PetStoreNegativeSteps.cs
@@ -1,0 +1,44 @@
+using TechTalk.SpecFlow;
+using AutomationFramework.API.BusinessLogic;
+using AutomationFramework.Core.Config;
+using RestSharp;
+using FluentAssertions;
+using Serilog;
+
+namespace AutomationFramework.API.StepDefinitions
+{
+    [Binding]
+    public class PetStoreNegativeSteps
+    {
+        private readonly PetBusinessLogic _petBusinessLogic;
+        private RestResponse _response;
+        private ScenarioContext _scenarioContext;
+        public PetStoreNegativeSteps(ScenarioContext scenarioContext)
+        {
+            var baseUrl = ConfigManager.GetConfigValue<string>("ApiBaseUrl");
+            _scenarioContext = scenarioContext;
+            _petBusinessLogic = new PetBusinessLogic(baseUrl);
+        }
+
+        [When(@"I retrieve a pet with an invalid ID")]
+        public void WhenIRetrieveAPetWithAnInvalidID()
+        {
+            var invalidPetId = -1; // Assuming -1 is an invalid ID
+            _response = _petBusinessLogic.GetPetById(invalidPetId);
+        }
+
+        [Then(@"the response status code should be 404")]
+        public void ThenTheResponseStatusCodeShouldBe404()
+        {
+            _response.StatusCode.Should().Be(System.Net.HttpStatusCode.NotFound);
+            Log.Information("Verified response status code: {StatusCode}", _response.StatusCode);
+        }
+
+        [Then(@"the response message should indicate that the pet was not found")]
+        public void ThenTheResponseMessageShouldIndicateThatThePetWasNotFound()
+        {
+            _response.Content.Should().Contain("Pet not found");
+            Log.Information("Verified response message: {Content}", _response.Content);
+        }
+    }
+}


### PR DESCRIPTION
This PR adds a new feature file and step definitions for negative testing of pet retrieval in the Pet Store API.

- Added `PetStoreNegative.feature` for negative scenarios.
- Created `PetStoreNegativeSteps.cs` for step definitions related to negative scenarios.

Scenarios covered:
- Retrieve a pet with an invalid ID and verify the response status code is 404 and the message indicates that the pet was not found.