### PR TITLE
Add Negative Test for Pet Retrieve API

### DIFF
--- a/API/Features/PetStoreNegative.feature
+++ b/API/Features/PetStoreNegative.feature
@@ -1,0 +1,8 @@
+@API @Negative
+Feature: PetStore API Negative Tests
+
+  Scenario: Retrieve pet by invalid ID
+    Given the PetStore API is available and accessible
+    When I retrieve the pet by ID "999999"
+    Then the response status code should be 404 for invalid ID
+    And the response should contain an error message "Pet not found"

--- a/API/StepDefinitions/PetStoreNegativeSteps.cs
+++ b/API/StepDefinitions/PetStoreNegativeSteps.cs
@@ -1,0 +1,50 @@
+using TechTalk.SpecFlow;
+using AutomationFramework.API.BusinessLogic;
+using AutomationFramework.Core.Config;
+using RestSharp;
+using FluentAssertions;
+using Serilog;
+
+namespace AutomationFramework.API.StepDefinitions
+{
+    [Binding]
+    public class PetStoreNegativeSteps
+    {
+        private readonly PetBusinessLogic _petBusinessLogic;
+        private RestResponse _response;
+        private ScenarioContext _scenarioContext;
+
+        public PetStoreNegativeSteps(ScenarioContext scenarioContext)
+        {
+            var baseUrl = ConfigManager.GetConfigValue<string>("ApiBaseUrl");
+            _scenarioContext = scenarioContext;
+            _petBusinessLogic = new PetBusinessLogic(baseUrl);
+        }
+
+        [Given(@"the PetStore API is available and accessible")]
+        public void GivenThePetStoreAPIIsAvailableAndAccessible()
+        {
+            Log.Information("Verified that PetStore API is available.");
+        }
+
+        [When(@"I retrieve the pet by ID "(.*)"")]
+        public void WhenIRetrieveThePetByID(string petId)
+        {
+            _response = _petBusinessLogic.GetPetById(long.Parse(petId));
+        }
+
+        [Then(@"the response status code should be 404 for invalid ID")]
+        public void ThenTheResponseStatusCodeShouldBe404ForInvalidID()
+        {
+            _response.StatusCode.Should().Be(System.Net.HttpStatusCode.NotFound, "Invalid pet ID should return 404 status code");
+            Log.Information("Verified response status code: 404 for invalid pet ID");
+        }
+
+        [Then(@"the response should contain an error message "(.*)"")]
+        public void ThenTheResponseShouldContainAnErrorMessage(string errorMessage)
+        {
+            _response.Content.Should().Contain(errorMessage, "Response should contain the expected error message");
+            Log.Information($"Verified response contains error message: {errorMessage}");
+        }
+    }
+}


### PR DESCRIPTION
This PR adds a negative test scenario for the PetStore API to retrieve a pet by an invalid ID. The test ensures that the API returns a 404 status code and an appropriate error message when an invalid pet ID is provided.

- Added a new feature file `PetStoreNegative.feature` with the negative test scenario.
- Created a new step definition file `PetStoreNegativeSteps.cs` to handle the steps for the negative test.

closes #<issue_number>