### PR TITLE
Add negative test for retrieving pet with invalid ID

### DIFF
--- a/API/Features/PetStoreNegativeScenarios.feature
+++ b/API/Features/PetStoreNegativeScenarios.feature
@@ -1,0 +1,7 @@
+Feature: PetStore Negative Scenarios
+  @API @Negative
+  Scenario: Retrieve pet with invalid ID
+    Given the PetStore API is available and accessible
+    And I set an invalid pet ID '999999'
+    When I retrieve the pet by ID
+    Then the response status code should be 404

--- a/API/StepDefinitions/PetStoreNegativeSteps.cs
+++ b/API/StepDefinitions/PetStoreNegativeSteps.cs
@@ -1,0 +1,23 @@
+using TechTalk.SpecFlow;
+using AutomationFramework.Core.Utilities;
+
+namespace AutomationFramework.API.StepDefinitions
+{
+    [Binding]
+    public class PetStoreNegativeSteps
+    {
+        private readonly ScenarioContext _scenarioContext;
+        private const string PetId = "PetID";
+
+        public PetStoreNegativeSteps(ScenarioContext scenarioContext)
+        {
+            _scenarioContext = scenarioContext;
+        }
+
+        [Given(@"I set an invalid pet ID '(.*)'")]
+        public void GivenISetAnInvalidPetID(long invalidPetId)
+        {
+            ScenarioContextHelper.SetOrReplace(_scenarioContext, PetId, invalidPetId);
+        }
+    }
+}


### PR DESCRIPTION
Added a new negative test scenario for retrieving a pet with an invalid ID. This includes:
- A new feature file `PetStoreNegativeScenarios.feature`
- A new step definition file `PetStoreNegativeSteps.cs`

closes #<issue_number>