### PR TITLE
Add Negative Test for Pet Retrieval

### DIFF
--- a/API/Features/PetStoreNegative.feature
+++ b/API/Features/PetStoreNegative.feature
@@ -1,0 +1,8 @@
+Feature: PetStore API Negative Scenarios
+
+  @API @Negative
+  Scenario: Retrieve pet with invalid ID
+    Given the PetStore API is available and accessible
+    When I retrieve the pet by ID '999999'
+    Then the response status code should be 404
+    And the response should contain an error message 'Pet not found'

--- a/API/StepDefinitions/PetStoreNegativeSteps.cs
+++ b/API/StepDefinitions/PetStoreNegativeSteps.cs
@@ -1,0 +1,38 @@
+using BoDi;
+using TechTalk.SpecFlow;
+using AutomationFramework.API.BusinessLogic;
+using AutomationFramework.Core.Config;
+using RestSharp;
+using FluentAssertions;
+using Serilog;
+
+namespace AutomationFramework.API.StepDefinitions
+{
+    [Binding]
+    public class PetStoreNegativeSteps
+    {
+        private readonly PetBusinessLogic _petBusinessLogic;
+        private RestResponse _response;
+        private ScenarioContext _scenarioContext;
+
+        public PetStoreNegativeSteps(ScenarioContext scenarioContext)
+        {
+            var baseUrl = ConfigManager.GetConfigValue<string>("ApiBaseUrl");
+            _scenarioContext = scenarioContext;
+            _petBusinessLogic = new PetBusinessLogic(baseUrl);
+        }
+
+        [When(@"I retrieve the pet by ID '(.*)'")]
+        public void WhenIRetrieveThePetByID(long petId)
+        {
+            _response = _petBusinessLogic.GetPetById(petId);
+        }
+
+        [Then(@"the response should contain an error message '(.*)'")]
+        public void ThenTheResponseShouldContainAnErrorMessage(string errorMessage)
+        {
+            _response.Content.Should().Contain(errorMessage);
+            Log.Information($"Verified error message in response: {errorMessage}");
+        }
+    }
+}


### PR DESCRIPTION
This pull request adds a new negative test scenario for retrieving a pet with an invalid ID. The following changes are included:

- New feature file `PetStoreNegative.feature` with a scenario to test pet retrieval with an invalid ID.
- New step definitions in `PetStoreNegativeSteps.cs` to handle the retrieval of a pet by an invalid ID and verify the error message in the response.

closes #<issue_number>