### PR TITLE
Add UI test to verify BlazeDemo page title – Ref: 1234

### DIFF
--- a/UI/Features/VerifyBlazeDemoTitle.feature
+++ b/UI/Features/VerifyBlazeDemoTitle.feature
@@ -1,0 +1,21 @@
+#language: en
+
+@UI @Positive
+Feature: Verify BlazeDemo Page Title
+  As a user
+  I want to verify the page title of BlazeDemo
+  So that I can ensure the website is loaded correctly
+
+  Scenario: Verify the page title of BlazeDemo
+    Given I navigate to 'https://blazedemo.com/'
+    Then the page title should be 'BlazeDemo'
+
+@UI @Negative
+Feature: Verify Incorrect BlazeDemo Page Title
+  As a user
+  I want to verify the page title of BlazeDemo
+  So that I can ensure the website is loaded correctly
+
+  Scenario: Verify the incorrect page title of BlazeDemo
+    Given I navigate to 'https://blazedemo.com/'
+    Then the page title should not be 'IncorrectTitle'

--- a/UI/StepDefinitions/VerifyBlazeDemoTitleSteps.cs
+++ b/UI/StepDefinitions/VerifyBlazeDemoTitleSteps.cs
@@ -1,0 +1,56 @@
+using OpenQA.Selenium;
+using NUnit.Framework;
+using TechTalk.SpecFlow;
+using AutomationFramework.Core.Utilities;
+
+namespace UI.StepDefinitions
+{
+    [Binding]
+    public class VerifyBlazeDemoTitleSteps
+    {
+        private readonly ScenarioContext _scenarioContext;
+        private readonly IWebDriver _driver;
+
+        public VerifyBlazeDemoTitleSteps(ScenarioContext scenarioContext)
+        {
+            _scenarioContext = scenarioContext;
+            _driver = (IWebDriver)_scenarioContext["WebDriver"];
+        }
+
+        [Given(@"I navigate to '(.*)'")]
+        public void GivenINavigateTo(string url)
+        {
+            _driver.Navigate().GoToUrl(url);
+        }
+
+        [Then(@"the page title should be '(.*)'")]
+        public void ThenThePageTitleShouldBe(string expectedTitle)
+        {
+            try
+            {
+                string actualTitle = _driver.Title;
+                Assert.That(actualTitle, Is.EqualTo(expectedTitle), $"Expected '{expectedTitle}' but found '{actualTitle}'");
+            }
+            catch (Exception ex)
+            {
+                ScreenshotHelper.CaptureScreenshot(_driver, "VerifyBlazeDemoTitle");
+                throw new Exception($"Assertion failed: {ex.Message}");
+            }
+        }
+
+        [Then(@"the page title should not be '(.*)'")]
+        public void ThenThePageTitleShouldNotBe(string incorrectTitle)
+        {
+            try
+            {
+                string actualTitle = _driver.Title;
+                Assert.That(actualTitle, Is.Not.EqualTo(incorrectTitle), $"Expected title not to be '{incorrectTitle}' but found '{actualTitle}'");
+            }
+            catch (Exception ex)
+            {
+                ScreenshotHelper.CaptureScreenshot(_driver, "VerifyBlazeDemoTitle");
+                throw new Exception($"Assertion failed: {ex.Message}");
+            }
+        }
+    }
+}


### PR DESCRIPTION
This pull request includes positive and negative test cases for verifying the page title of BlazeDemo.

- Positive Test Case: Verify the page title is 'BlazeDemo'
- Negative Test Case: Verify the page title is not 'IncorrectTitle'

Files added:
- `UI/Features/VerifyBlazeDemoTitle.feature`
- `UI/StepDefinitions/VerifyBlazeDemoTitleSteps.cs`