### PR TITLE
Add UI test to verify BlazeDemo page title – Ref: 7890

### DIFF
--- a/UI/Features/VerifyBlazeDemoTitle.feature
+++ b/UI/Features/VerifyBlazeDemoTitle.feature
@@ -1,0 +1,19 @@
+@UI @Positive
+Feature: Verify BlazeDemo Page Title
+  As a user
+  I want to verify the title of the BlazeDemo homepage
+  So that I can ensure the page loads correctly
+
+  Scenario: Verify the title of BlazeDemo homepage
+    Given I navigate to 'https://blazedemo.com/'
+    Then the page title should be 'BlazeDemo'
+
+@UI @Negative
+Feature: Verify BlazeDemo Page Title with Incorrect URL
+  As a user
+  I want to verify the title of the BlazeDemo homepage with an incorrect URL
+  So that I can ensure the page does not load correctly
+
+  Scenario: Verify the title of BlazeDemo homepage with incorrect URL
+    Given I navigate to 'https://blazedemo.com/incorrect'
+    Then the page title should not be 'BlazeDemo'

--- a/UI/StepDefinitions/VerifyBlazeDemoTitleSteps.cs
+++ b/UI/StepDefinitions/VerifyBlazeDemoTitleSteps.cs
@@ -1,0 +1,56 @@
+using OpenQA.Selenium;
+using NUnit.Framework;
+using TechTalk.SpecFlow;
+using AutomationFramework.Core.Utilities;
+
+namespace AutomationFramework.UI.StepDefinitions
+{
+    [Binding]
+    public class VerifyBlazeDemoTitleSteps
+    {
+        private readonly ScenarioContext _scenarioContext;
+        private readonly IWebDriver _driver;
+
+        public VerifyBlazeDemoTitleSteps(ScenarioContext scenarioContext)
+        {
+            _scenarioContext = scenarioContext;
+            _driver = (IWebDriver)_scenarioContext["WebDriver"];
+        }
+
+        [Given(@"I navigate to '(.*)'")]
+        public void GivenINavigateTo(string url)
+        {
+            _driver.Navigate().GoToUrl(url);
+        }
+
+        [Then(@"the page title should be '(.*)'")]
+        public void ThenThePageTitleShouldBe(string expectedTitle)
+        {
+            try
+            {
+                string actualTitle = _driver.Title;
+                Assert.That(actualTitle, Is.EqualTo(expectedTitle), $"Expected {expectedTitle} but found {actualTitle}");
+            }
+            catch (Exception ex)
+            {
+                ScreenshotHelper.CaptureScreenshot(_driver, "VerifyBlazeDemoTitle");
+                throw new Exception($"Assertion failed: {ex.Message}");
+            }
+        }
+
+        [Then(@"the page title should not be '(.*)'")]
+        public void ThenThePageTitleShouldNotBe(string expectedTitle)
+        {
+            try
+            {
+                string actualTitle = _driver.Title;
+                Assert.That(actualTitle, Is.Not.EqualTo(expectedTitle), $"Expected title not to be {expectedTitle} but found {actualTitle}");
+            }
+            catch (Exception ex)
+            {
+                ScreenshotHelper.CaptureScreenshot(_driver, "VerifyBlazeDemoTitle");
+                throw new Exception($"Assertion failed: {ex.Message}");
+            }
+        }
+    }
+}


### PR DESCRIPTION
This pull request adds positive and negative UI test cases for verifying the BlazeDemo page title.

- Positive test case: Verify the title of BlazeDemo homepage
- Negative test case: Verify the title of BlazeDemo homepage with incorrect URL

The tests are implemented following the BDD standards and EliteAOneInc framework conventions.