### PR TITLE
Add UI test to verify BlazeDemo page title

### DIFF
--- a/UI/Features/VerifyBlazeDemoTitle.feature
+++ b/UI/Features/VerifyBlazeDemoTitle.feature
@@ -1,0 +1,5 @@
+Feature: Verify BlazeDemo Page Title
+  @UI @Positive
+  Scenario: Verify the page title of BlazeDemo
+    Given I navigate to 'https://blazedemo.com/'
+    Then the page title should be 'BlazeDemo'

--- a/UI/StepDefinitions/VerifyBlazeDemoTitleSteps.cs
+++ b/UI/StepDefinitions/VerifyBlazeDemoTitleSteps.cs
@@ -1,0 +1,42 @@
+using OpenQA.Selenium;
+using NUnit.Framework;
+using TechTalk.SpecFlow;
+using AutomationFramework.Core.Utilities;
+using System;
+
+namespace AutomationFramework.UI.StepDefinitions
+{
+    [Binding]
+    public class VerifyBlazeDemoTitleSteps
+    {
+        private readonly IWebDriver _driver;
+        private readonly ScenarioContext _scenarioContext;
+
+        public VerifyBlazeDemoTitleSteps(ScenarioContext scenarioContext)
+        {
+            _scenarioContext = scenarioContext;
+            _driver = (IWebDriver)_scenarioContext["WebDriver"];
+        }
+
+        [Given(@"I navigate to '(.*)'")]
+        public void GivenINavigateTo(string url)
+        {
+            _driver.Navigate().GoToUrl(url);
+        }
+
+        [Then(@"the page title should be '(.*)'")]
+        public void ThenThePageTitleShouldBe(string expectedTitle)
+        {
+            try
+            {
+                var actualTitle = _driver.Title;
+                Assert.That(actualTitle, Is.EqualTo(expectedTitle), $"Expected {{expectedTitle}} but found {{actualTitle}}");
+            }
+            catch (Exception ex)
+            {
+                ScreenshotHelper.CaptureScreenshot(_driver, _scenarioContext.ScenarioInfo.Title.Replace(" ", "_"));
+                throw new Exception($"Assertion failed: {{ex.Message}}");
+            }
+        }
+    }
+}


### PR DESCRIPTION
This pull request adds a new UI test to verify the page title of BlazeDemo. The test navigates to 'https://blazedemo.com/' and asserts that the page title is 'BlazeDemo'.

Feature file: `UI/Features/VerifyBlazeDemoTitle.feature`
Step definition file: `UI/StepDefinitions/VerifyBlazeDemoTitleSteps.cs`