### PR TITLE
Add negative test for pet retrieval

### DIFF
--- a/API/Features/PetStoreNegative.feature
+++ b/API/Features/PetStoreNegative.feature
@@ -1,0 +1,6 @@
+Feature: PetStore API Negative Tests
+  @API @Negative
+  Scenario: Retrieve pet with invalid ID
+    Given the PetStore API is available and accessible
+    When I retrieve the pet by ID '999999'
+    Then the response status code should be 404

--- a/API/StepDefinitions/PetStoreNegativeSteps.cs
+++ b/API/StepDefinitions/PetStoreNegativeSteps.cs
@@ -1,0 +1,38 @@
+using BoDi;
+using TechTalk.SpecFlow;
+using AutomationFramework.API.BusinessLogic;
+using AutomationFramework.Core.Config;
+using RestSharp;
+using FluentAssertions;
+using Serilog;
+
+namespace AutomationFramework.API.StepDefinitions
+{
+    [Binding]
+    public class PetStoreNegativeSteps
+    {
+        private readonly PetBusinessLogic _petBusinessLogic;
+        private RestResponse _response;
+        private ScenarioContext _scenarioContext;
+
+        public PetStoreNegativeSteps(ScenarioContext scenarioContext)
+        {
+            var baseUrl = ConfigManager.GetConfigValue<string>("ApiBaseUrl");
+            _scenarioContext = scenarioContext;
+            _petBusinessLogic = new PetBusinessLogic(baseUrl);
+        }
+
+        [When(@"I retrieve the pet by ID '(.*)'")]
+        public void WhenIRetrieveThePetByID(long petId)
+        {
+            _response = _petBusinessLogic.GetPetById(petId);
+        }
+
+        [Then(@"the response status code should be (.*)")]
+        public void ThenTheResponseStatusCodeShouldBe(int expectedStatusCode)
+        {
+            _response.StatusCode.Should().Be((System.Net.HttpStatusCode)expectedStatusCode);
+            Log.Information($"Verified response status code: {_response.StatusCode}");
+        }
+    }
+}


### PR DESCRIPTION
This PR adds a new negative test for retrieving a pet with an invalid ID. The test verifies that the response status code is 404 when attempting to retrieve a pet with a non-existent ID.

Changes:
- Added `PetStoreNegative.feature` with a scenario for retrieving a pet with an invalid ID.
- Added `PetStoreNegativeSteps.cs` with step definitions for the new scenario.

Branch: `feature/API-NegativePetTests_20231127_A_1234_ABCD`