### PR TITLE
Add negative test for Pet retrieval

### DIFF
--- a/API/Features/PetStoreNegative.feature
+++ b/API/Features/PetStoreNegative.feature
@@ -1,0 +1,7 @@
+Feature: PetStore API Negative Scenarios
+  @API @Negative
+  Scenario: Retrieve non-existent pet by ID
+    Given the PetStore API is available and accessible
+    When I retrieve the pet by ID '999999'
+    Then the response status code should be 404
+    And the response error message should be 'Pet not found'

--- a/API/StepDefinitions/PetStoreNegativeSteps.cs
+++ b/API/StepDefinitions/PetStoreNegativeSteps.cs
@@ -1,0 +1,37 @@
+using BoDi;
+using TechTalk.SpecFlow;
+using AutomationFramework.API.BusinessLogic;
+using AutomationFramework.Core.Config;
+using RestSharp;
+using FluentAssertions;
+using Serilog;
+
+namespace AutomationFramework.API.StepDefinitions
+{
+    [Binding]
+    public class PetStoreNegativeSteps
+    {
+        private readonly PetBusinessLogic _petBusinessLogic;
+        private RestResponse _response;
+        private ScenarioContext _scenarioContext;
+        public PetStoreNegativeSteps(ScenarioContext scenarioContext)
+        {
+            var baseUrl = ConfigManager.GetConfigValue<string>("ApiBaseUrl");
+            _scenarioContext = scenarioContext;
+            _petBusinessLogic = new PetBusinessLogic(baseUrl);
+        }
+
+        [When(@"I retrieve the pet by ID '(.*)'")]
+        public void WhenIRetrieveThePetByID(long petId)
+        {
+            _response = _petBusinessLogic.GetPetById(petId);
+        }
+
+        [Then(@"the response error message should be '(.*)'")]
+        public void ThenTheResponseErrorMessageShouldBe(string expectedErrorMessage)
+        {
+            _response.Content.Should().Contain(expectedErrorMessage);
+            Log.Information("Verified error message: {ErrorMessage}", expectedErrorMessage);
+        }
+    }
+}


### PR DESCRIPTION
This PR adds a new negative test scenario for retrieving a non-existent pet by ID in the PetStore API.

closes #1