### PR TITLE
Add negative test for Pet retrieval with invalid ID

### DIFF
--- a/API/Features/PetStoreNegative.feature
+++ b/API/Features/PetStoreNegative.feature
@@ -1,0 +1,13 @@
+#language: en
+
+@API @Negative
+Feature: PetStore Negative Scenarios
+  As a user of the PetStore API
+  I want to ensure that invalid operations are handled gracefully
+  So that the system remains robust and secure
+
+  Scenario: Retrieve pet with invalid ID
+    Given the PetStore API is available and accessible
+    When I retrieve the pet by ID 'invalidID'
+    Then the response status code should be 404
+    And the response should contain an error message 'Pet not found'

--- a/API/StepDefinitions/PetStoreNegativeSteps.cs
+++ b/API/StepDefinitions/PetStoreNegativeSteps.cs
@@ -1,0 +1,38 @@
+using BoDi;
+using TechTalk.SpecFlow;
+using AutomationFramework.API.BusinessLogic;
+using AutomationFramework.Core.Config;
+using RestSharp;
+using FluentAssertions;
+using Serilog;
+
+namespace AutomationFramework.API.StepDefinitions
+{
+    [Binding]
+    public class PetStoreNegativeSteps
+    {
+        private readonly PetBusinessLogic _petBusinessLogic;
+        private RestResponse _response;
+        private ScenarioContext _scenarioContext;
+        private string PetId = "PetID";
+        public PetStoreNegativeSteps(ScenarioContext scenarioContext)
+        {
+            var baseUrl = ConfigManager.GetConfigValue<string>("ApiBaseUrl");
+            _scenarioContext = scenarioContext;
+            _petBusinessLogic = new PetBusinessLogic(baseUrl);
+        }
+
+        [When(@"I retrieve the pet by ID '(.*)'")]
+        public void WhenIRetrieveThePetByID(string petId)
+        {
+            _response = _petBusinessLogic.GetPetById(petId);
+        }
+
+        [Then(@"the response should contain an error message '(.*)'")]
+        public void ThenTheResponseShouldContainAnErrorMessage(string errorMessage)
+        {
+            _response.Content.Should().Contain(errorMessage);
+            Log.Information("Verified error message in response: {ErrorMessage}", errorMessage);
+        }
+    }
+}


### PR DESCRIPTION
This PR adds a new negative test scenario for retrieving a pet with an invalid ID in the PetStore API. It ensures that the API returns a 404 status code and an appropriate error message when an invalid pet ID is provided.

Files Added:
- API/Features/PetStoreNegative.feature
- API/StepDefinitions/PetStoreNegativeSteps.cs

closes #42