### PR TITLE
Add negative test for Pet retrieval with invalid long integer ID

### DIFF
--- a/API/Features/PetStoreNegative.feature
+++ b/API/Features/PetStoreNegative.feature
@@ -1,0 +1,13 @@
+# language: en
+
+@API @Negative
+Feature: PetStore API Negative Scenarios
+  As a user of the PetStore API
+  I want to ensure that invalid operations are handled gracefully
+  So that I receive appropriate error messages and status codes
+
+  Scenario: Retrieve pet with invalid long integer ID
+    Given I have an invalid long integer pet ID
+    When I retrieve the pet by ID
+    Then the response status code should be 404
+    And the response error message should be 'Pet not found'

--- a/API/StepDefinitions/PetStoreNegativeSteps.cs
+++ b/API/StepDefinitions/PetStoreNegativeSteps.cs
@@ -1,0 +1,52 @@
+using System;
+using System.Net;
+using FluentAssertions;
+using TechTalk.SpecFlow;
+using AutomationFramework.Core.Utilities;
+using AutomationFramework.API.Clients;
+
+namespace AutomationFramework.API.StepDefinitions
+{
+    [Binding]
+    public class PetStoreNegativeSteps
+    {
+        private readonly ScenarioContext _scenarioContext;
+        private readonly PetStoreApiClient _petStoreApiClient;
+        private long _invalidPetId;
+        private HttpStatusCode _responseStatusCode;
+        private string _responseErrorMessage;
+
+        public PetStoreNegativeSteps(ScenarioContext scenarioContext)
+        {
+            _scenarioContext = scenarioContext;
+            _petStoreApiClient = new PetStoreApiClient();
+        }
+
+        [Given("I have an invalid long integer pet ID")]
+        public void GivenIHaveAnInvalidLongIntegerPetID()
+        {
+            _invalidPetId = 9223372036854775807; // Example of a long integer value
+            _scenarioContext["InvalidPetId"] = _invalidPetId;
+        }
+
+        [When("I retrieve the pet by ID")]
+        public void WhenIRetrieveThePetByID()
+        {
+            var response = _petStoreApiClient.GetPetById(_invalidPetId);
+            _responseStatusCode = response.StatusCode;
+            _responseErrorMessage = response.Content;
+        }
+
+        [Then("the response status code should be 404")]
+        public void ThenTheResponseStatusCodeShouldBe404()
+        {
+            _responseStatusCode.Should().Be(HttpStatusCode.NotFound);
+        }
+
+        [Then("the response error message should be 'Pet not found'")]
+        public void ThenTheResponseErrorMessageShouldBePetNotFound()
+        {
+            _responseErrorMessage.Should().Contain("Pet not found");
+        }
+    }
+}


### PR DESCRIPTION
This PR adds a new negative test scenario for retrieving a pet with an invalid long integer ID in the PetStore API. It ensures that the API returns a 404 status code and an appropriate error message when an invalid pet ID is provided.

Files Added:
- API/Features/PetStoreNegative.feature
- API/StepDefinitions/PetStoreNegativeSteps.cs