### PR TITLE
Add negative test for pet retrieval with invalid ID -- Ref: 1234

### DIFF
--- a/API/Features/PetStoreNegative.feature
+++ b/API/Features/PetStoreNegative.feature
@@ -1,0 +1,8 @@
+@API @Negative
+Feature: PetStore API Negative Tests
+
+  Scenario: Retrieve a pet with an invalid ID
+    Given the PetStore API is available and accessible
+    When I retrieve the pet by ID '999999999'
+    Then the response status code should be 404
+    And the response should contain an error message 'Pet not found'

--- a/API/StepDefinitions/PetStoreNegativeSteps.cs
+++ b/API/StepDefinitions/PetStoreNegativeSteps.cs
@@ -1,0 +1,38 @@
+using BoDi;
+using TechTalk.SpecFlow;
+using AutomationFramework.API.BusinessLogic;
+using AutomationFramework.Core.Config;
+using RestSharp;
+using FluentAssertions;
+using Serilog;
+
+namespace AutomationFramework.API.StepDefinitions
+{
+    [Binding]
+    public class PetStoreNegativeSteps
+    {
+        private readonly PetBusinessLogic _petBusinessLogic;
+        private RestResponse _response;
+        private ScenarioContext _scenarioContext;
+
+        public PetStoreNegativeSteps(ScenarioContext scenarioContext)
+        {
+            var baseUrl = ConfigManager.GetConfigValue<string>("ApiBaseUrl");
+            _scenarioContext = scenarioContext;
+            _petBusinessLogic = new PetBusinessLogic(baseUrl);
+        }
+
+        [When(@"I retrieve the pet by ID '(.*)'")]
+        public void WhenIRetrieveThePetByID(long petId)
+        {
+            _response = _petBusinessLogic.GetPetById(petId);
+        }
+
+        [Then(@"the response should contain an error message '(.*)'")]
+        public void ThenTheResponseShouldContainAnErrorMessage(string expectedErrorMessage)
+        {
+            _response.Content.Should().Contain(expectedErrorMessage);
+            Log.Information($"Verified error message in response: {expectedErrorMessage}");
+        }
+    }
+}


### PR DESCRIPTION
This PR adds a new negative test case for retrieving a pet with an invalid ID in the PetStore API.