### PR TITLE
Add Negative Test for Pet Retrieval

### DIFF
--- a/API/Features/NegativePetRetrieval.feature
+++ b/API/Features/NegativePetRetrieval.feature
@@ -1,0 +1,5 @@
+Feature: Negative Pet Retrieval
+  Scenario: Retrieve a pet with an invalid ID
+    Given I have an invalid pet ID 'invalid_id'
+    When I retrieve the pet by ID 'invalid_id'
+    Then I should receive a 404 Not Found response

--- a/API/StepDefinitions/NegativePetRetrievalSteps.cs
+++ b/API/StepDefinitions/NegativePetRetrievalSteps.cs
@@ -1,0 +1,38 @@
+using TechTalk.SpecFlow;
+using NUnit.Framework;
+
+namespace API.StepDefinitions
+{
+    [Binding]
+    public class NegativePetRetrievalSteps
+    {
+        private readonly ScenarioContext _scenarioContext;
+        private readonly PetStoreApiClient _petStoreApiClient;
+        private string _invalidPetId;
+        private HttpResponseMessage _response;
+
+        public NegativePetRetrievalSteps(ScenarioContext scenarioContext, PetStoreApiClient petStoreApiClient)
+        {
+            _scenarioContext = scenarioContext;
+            _petStoreApiClient = petStoreApiClient;
+        }
+
+        [Given(@"I have an invalid pet ID '(.*)'")]
+        public void GivenIHaveAnInvalidPetID(string invalidPetId)
+        {
+            _invalidPetId = invalidPetId;
+        }
+
+        [When(@"I retrieve the pet by ID '(.*)'")]
+        public async Task WhenIRetrieveThePetByID(string petId)
+        {
+            _response = await _petStoreApiClient.GetPetByIdAsync(petId);
+        }
+
+        [Then(@"I should receive a 404 Not Found response")]
+        public void ThenIShouldReceiveA404NotFoundResponse()
+        {
+            Assert.AreEqual(HttpStatusCode.NotFound, _response.StatusCode);
+        }
+    }
+}


### PR DESCRIPTION
This PR adds a new negative test scenario for retrieving a pet with an invalid ID.

Feature file: `API/Features/NegativePetRetrieval.feature`
Step definitions: `API/StepDefinitions/NegativePetRetrievalSteps.cs`

The test ensures that attempting to retrieve a pet with an invalid ID results in a 404 Not Found response.