### PR TITLE
Add API test – Ref: 1234

### DIFF
--- a/API/Features/PetRetrievalNegative.feature
+++ b/API/Features/PetRetrievalNegative.feature
@@ -1,0 +1,7 @@
+Feature: Pet Retrieval Negative Test
+  @API @Negative
+  Scenario: Retrieve a pet with non-existent ID
+    Given the PetStore API is available and accessible
+    When I retrieve the pet by ID '999999999'
+    Then the response status code should be 404
+    And the error message should be 'Pet not found'

--- a/API/StepDefinitions/PetRetrievalNegativeSteps.cs
+++ b/API/StepDefinitions/PetRetrievalNegativeSteps.cs
@@ -1,0 +1,50 @@
+using TechTalk.SpecFlow;
+using AutomationFramework.API.BusinessLogic;
+using AutomationFramework.Core.Config;
+using RestSharp;
+using FluentAssertions;
+using Serilog;
+
+namespace AutomationFramework.API.StepDefinitions
+{
+    [Binding]
+    public class PetRetrievalNegativeSteps
+    {
+        private readonly PetBusinessLogic _petBusinessLogic;
+        private RestResponse _response;
+        private ScenarioContext _scenarioContext;
+        private string PetId = "PetID";
+        public PetRetrievalNegativeSteps(ScenarioContext scenarioContext)
+        {
+            var baseUrl = ConfigManager.GetConfigValue<string>("ApiBaseUrl");
+            _scenarioContext = scenarioContext;
+            _petBusinessLogic = new PetBusinessLogic(baseUrl);
+        }
+
+        [Given("the PetStore API is available and accessible")]
+        public void GivenThePetStoreAPIIsAvailableAndAccessible()
+        {
+            Log.Information("Verified that PetStore API is available.");
+        }
+
+        [When("I retrieve the pet by ID '(.*)'")]
+        public void WhenIRetrieveThePetByID(long petId)
+        {
+            _response = _petBusinessLogic.GetPetById(petId);
+        }
+
+        [Then("the response status code should be (.*)")]
+        public void ThenTheResponseStatusCodeShouldBe(int expectedStatusCode)
+        {
+            _response.StatusCode.Should().Be((System.Net.HttpStatusCode)expectedStatusCode);
+            Log.Information($"Verified response status code: {_response.StatusCode}");
+        }
+
+        [Then("the error message should be '(.*)'")]
+        public void ThenTheErrorMessageShouldBe(string expectedErrorMessage)
+        {
+            _response.Content.Should().Contain(expectedErrorMessage);
+            Log.Information($"Verified error message: {expectedErrorMessage}");
+        }
+    }
+}


### PR DESCRIPTION
Added a negative test for retrieving a pet with a non-existent ID.

- Created a new feature file `PetRetrievalNegative.feature`.
- Added step definitions in `PetRetrievalNegativeSteps.cs`.

This ensures that the API returns a 404 status code and appropriate error message when attempting to retrieve a pet that does not exist.