### PR TITLE
Add Negative Test for Pet Retrieval with Invalid ID

### DIFF
--- a/API/Features/PetStoreNegative.feature
+++ b/API/Features/PetStoreNegative.feature
@@ -1,0 +1,15 @@
+@PetStoreAPI @Regression @APITesting @NegativeScenario
+Feature: Pet Store API Negative Scenarios
+  As an API consumer
+  I want to handle errors gracefully
+  So that I can ensure the API responds correctly to invalid requests
+
+Background:
+  Given the PetStore API is available and accessible
+
+@RetrievePet @NegativeScenario
+Scenario: Retrieve a non-existent pet by invalid ID
+  Given I have an invalid pet ID
+  When I retrieve the pet by ID
+  Then the response status code should be 404
+  And the error message should indicate that the pet was not found

--- a/API/StepDefinitions/PetStoreNegativeSteps.cs
+++ b/API/StepDefinitions/PetStoreNegativeSteps.cs
@@ -1,0 +1,40 @@
+using BoDi;
+using TechTalk.SpecFlow;
+using AutomationFramework.API.BusinessLogic;
+using AutomationFramework.Core.Config;
+using RestSharp;
+using FluentAssertions;
+using Serilog;
+
+namespace AutomationFramework.API.StepDefinitions
+{
+    [Binding]
+    public class PetStoreNegativeSteps
+    {
+        private readonly PetBusinessLogic _petBusinessLogic;
+        private RestResponse _response;
+        private ScenarioContext _scenarioContext;
+        private string InvalidPetId = "InvalidPetID";
+
+        public PetStoreNegativeSteps(ScenarioContext scenarioContext)
+        {
+            var baseUrl = ConfigManager.GetConfigValue<string>("ApiBaseUrl");
+            _scenarioContext = scenarioContext;
+            _petBusinessLogic = new PetBusinessLogic(baseUrl);
+        }
+
+        [Given(@"I have an invalid pet ID")]
+        public void GivenIHaveAnInvalidPetID()
+        {
+            ScenarioContextHelper.SetOrReplace(_scenarioContext, InvalidPetId, -1);
+            Log.Information("Set an invalid pet ID for testing.");
+        }
+
+        [Then(@"the error message should indicate that the pet was not found")]
+        public void ThenTheErrorMessageShouldIndicateThatThePetWasNotFound()
+        {
+            _response.Content.Should().Contain("Pet not found", "The error message should indicate that the pet was not found.");
+            Log.Information("Verified error message: Pet not found.");
+        }
+    }
+}


### PR DESCRIPTION
This PR adds a new negative test case for retrieving a pet with an invalid ID. The changes include:

- New feature file `PetStoreNegative.feature` under `API/Features`.
- New step definitions in `PetStoreNegativeSteps.cs` to handle invalid pet ID and verify the 404 response and error message.

This ensures that the API correctly handles requests for non-existent pets.