### PR TITLE
Add negative test for Pet retrieval with error message verification

### DIFF
--- a/API/Features/PetStoreNegativeRetrieval.feature
+++ b/API/Features/PetStoreNegativeRetrieval.feature
@@ -1,0 +1,12 @@
+#language: en
+
+@API @Negative
+Feature: Negative Pet Retrieval
+  As a user of the PetStore API
+  I want to ensure that retrieving a non-existent pet returns the correct error response
+
+  Scenario: Retrieve a pet with an invalid ID
+    Given the PetStore API is available and accessible
+    When I retrieve the pet by ID '999999999999'
+    Then the response status code should be 404
+    And the response error message should be 'Pet not found'

--- a/API/StepDefinitions/PetStoreNegativeSteps.cs
+++ b/API/StepDefinitions/PetStoreNegativeSteps.cs
@@ -1,0 +1,37 @@
+using BoDi;
+using TechTalk.SpecFlow;
+using AutomationFramework.API.BusinessLogic;
+using AutomationFramework.Core.Config;
+using RestSharp;
+using FluentAssertions;
+using Serilog;
+
+namespace AutomationFramework.API.StepDefinitions
+{
+    [Binding]
+    public class PetStoreNegativeSteps
+    {
+        private readonly PetBusinessLogic _petBusinessLogic;
+        private RestResponse _response;
+        private ScenarioContext _scenarioContext;
+        public PetStoreNegativeSteps(ScenarioContext scenarioContext)
+        {
+            var baseUrl = ConfigManager.GetConfigValue<string>("ApiBaseUrl");
+            _scenarioContext = scenarioContext;
+            _petBusinessLogic = new PetBusinessLogic(baseUrl);
+        }
+
+        [When(@"I retrieve the pet by ID '(.*)'")]
+        public void WhenIRetrieveThePetByID(string petId)
+        {
+            _response = _petBusinessLogic.GetPetById(long.Parse(petId));
+        }
+
+        [Then(@"the response error message should be '(.*)'")]
+        public void ThenTheResponseErrorMessageShouldBe(string expectedErrorMessage)
+        {
+            _response.Content.Should().Contain(expectedErrorMessage);
+            Log.Information($"Verified response error message: {_response.Content}");
+        }
+    }
+}


### PR DESCRIPTION
This PR adds a new negative test for Pet retrieval to verify the error message when a non-existent pet ID is used.

- Added feature file `PetStoreNegativeRetrieval.feature`
- Added step definitions in `PetStoreNegativeSteps.cs`

Closes #79