### PR TITLE
Add BlazeDemo UI Tests

### DIFF
--- a/UI/Features/BlazeDemo.feature
+++ b/UI/Features/BlazeDemo.feature
@@ -1,0 +1,15 @@
+#language: en
+
+@UI @Positive
+Feature: BlazeDemo Positive Test Cases
+
+  Scenario: Verify BlazeDemo Home Page Title
+    Given I navigate to BlazeDemo home page
+    Then the page title should be 'BlazeDemo'
+
+@UI @Negative
+Feature: BlazeDemo Negative Test Cases
+
+  Scenario: Verify BlazeDemo Home Page Title with Incorrect Title
+    Given I navigate to BlazeDemo home page
+    Then the page title should not be 'IncorrectTitle'

--- a/UI/StepDefinitions/BlazeDemoSteps.cs
+++ b/UI/StepDefinitions/BlazeDemoSteps.cs
@@ -1,0 +1,39 @@
+using TechTalk.SpecFlow;
+using AutomationFramework.Core.Config;
+using OpenQA.Selenium;
+using FluentAssertions;
+
+namespace AutomationFramework.UI.StepDefinitions
+{
+    [Binding]
+    public class BlazeDemoSteps
+    {
+        private readonly IWebDriver _driver;
+
+        public BlazeDemoSteps(ScenarioContext scenarioContext)
+        {
+            _driver = (IWebDriver)scenarioContext["WebDriver"];
+        }
+
+        [Given(@"I navigate to BlazeDemo home page")]
+        public void GivenINavigateToBlazeDemoHomePage()
+        {
+            var url = ConfigManager.GetConfigValue<string>("BlazeDemoUrl");
+            _driver.Navigate().GoToUrl(url);
+        }
+
+        [Then(@"the page title should be '(.*)'")]
+        public void ThenThePageTitleShouldBe(string expectedTitle)
+        {
+            var actualTitle = _driver.Title;
+            actualTitle.Should().Be(expectedTitle, $"Expected title to be {expectedTitle} but was {actualTitle}");
+        }
+
+        [Then(@"the page title should not be '(.*)'")]
+        public void ThenThePageTitleShouldNotBe(string incorrectTitle)
+        {
+            var actualTitle = _driver.Title;
+            actualTitle.Should().NotBe(incorrectTitle, $"Expected title not to be {incorrectTitle} but it was");
+        }
+    }
+}


### PR DESCRIPTION
This PR adds positive and negative test cases for BlazeDemo home page title verification.

- Added feature file `BlazeDemo.feature` with positive and negative scenarios.
- Added step definitions in `BlazeDemoSteps.cs` to support the feature file.

closes #123