### PR TITLE
Add test to verify BlazeDemo page title

### DIFF
--- a/UI/Features/VerifyBlazeDemoTitle.feature
+++ b/UI/Features/VerifyBlazeDemoTitle.feature
@@ -1,0 +1,5 @@
+@UI @Positive
+Feature: Verify BlazeDemo Page Title
+  Scenario: Verify the page title of BlazeDemo
+    Given I navigate to 'https://blazedemo.com/'
+    Then the page title should be 'BlazeDemo'

--- a/UI/StepDefinitions/BlazeDemoSteps.cs
+++ b/UI/StepDefinitions/BlazeDemoSteps.cs
@@ -1,0 +1,31 @@
+using TechTalk.SpecFlow;
+using AutomationFramework.Core.Config;
+using OpenQA.Selenium;
+using FluentAssertions;
+
+namespace AutomationFramework.UI.StepDefinitions
+{
+    [Binding]
+    public class BlazeDemoSteps
+    {
+        private readonly IWebDriver _driver;
+
+        public BlazeDemoSteps(ScenarioContext scenarioContext)
+        {
+            _driver = (IWebDriver)scenarioContext["WebDriver"];
+        }
+
+        [Given(@"I navigate to '(.*)'")]
+        public void GivenINavigateTo(string url)
+        {
+            _driver.Navigate().GoToUrl(url);
+        }
+
+        [Then(@"the page title should be '(.*)'")]
+        public void ThenThePageTitleShouldBe(string expectedTitle)
+        {
+            var actualTitle = _driver.Title;
+            actualTitle.Should().Be(expectedTitle, $"Expected page title to be '{expectedTitle}' but was '{actualTitle}'");
+        }
+    }
+}


### PR DESCRIPTION
This PR adds a new UI test to verify the page title of https://blazedemo.com/. The test navigates to the BlazeDemo website and checks if the page title is 'BlazeDemo'.

Files added:
- `UI/Features/VerifyBlazeDemoTitle.feature`
- `UI/StepDefinitions/BlazeDemoSteps.cs`