### PR TITLE
Add BlazeDemo UI Tests

### DIFF
--- a/UI/Features/BlazeDemo.feature
+++ b/UI/Features/BlazeDemo.feature
@@ -1,0 +1,13 @@
+# BlazeDemo.feature
+
+Feature: BlazeDemo Tests
+
+  @UI @Positive
+  Scenario: Verify BlazeDemo Home Page Title
+    Given I navigate to 'https://blazedemo.com/'
+    Then the page title should be 'BlazeDemo'
+
+  @UI @Negative
+  Scenario: Verify BlazeDemo Home Page Title with Incorrect Title
+    Given I navigate to 'https://blazedemo.com/'
+    Then the page title should not be 'Incorrect Title'

--- a/UI/StepDefinitions/BlazeDemoSteps.cs
+++ b/UI/StepDefinitions/BlazeDemoSteps.cs
@@ -1,0 +1,39 @@
+using TechTalk.SpecFlow;
+using AutomationFramework.Core.Config;
+using OpenQA.Selenium;
+using FluentAssertions;
+using AutomationFramework.Core.Utilities;
+
+namespace AutomationFramework.UI.StepDefinitions
+{
+    [Binding]
+    public class BlazeDemoSteps
+    {
+        private readonly IWebDriver _driver;
+
+        public BlazeDemoSteps(ScenarioContext scenarioContext)
+        {
+            _driver = (IWebDriver)scenarioContext["WebDriver"];
+        }
+
+        [Given(@"I navigate to '(.*)'")]
+        public void GivenINavigateTo(string url)
+        {
+            _driver.Navigate().GoToUrl(url);
+        }
+
+        [Then(@"the page title should be '(.*)'")]
+        public void ThenThePageTitleShouldBe(string expectedTitle)
+        {
+            var actualTitle = _driver.Title;
+            actualTitle.Should().Be(expectedTitle, $"Expected title to be '{expectedTitle}' but was '{actualTitle}'");
+        }
+
+        [Then(@"the page title should not be '(.*)'")]
+        public void ThenThePageTitleShouldNotBe(string unexpectedTitle)
+        {
+            var actualTitle = _driver.Title;
+            actualTitle.Should().NotBe(unexpectedTitle, $"Expected title not to be '{unexpectedTitle}' but it was");
+        }
+    }
+}


### PR DESCRIPTION
This PR adds positive and negative test cases for BlazeDemo home page title verification.

- Added feature file `BlazeDemo.feature` with scenarios for verifying the page title.
- Added step definitions in `BlazeDemoSteps.cs` to support the feature file.

closes #123