### PR TITLE
Add test to verify BlazeDemo page title

### DIFF
--- a/UI/Features/BlazeDemoTitleVerification.feature
+++ b/UI/Features/BlazeDemoTitleVerification.feature
@@ -1,0 +1,11 @@
+#language: en
+
+@UI @Positive
+Feature: Verify BlazeDemo Page Title
+  As a user
+  I want to verify the page title of BlazeDemo
+  So that I can ensure I am on the correct page
+
+  Scenario: Verify BlazeDemo page title
+    Given I navigate to 'https://blazedemo.com/'
+    Then the page title should be 'BlazeDemo'

--- a/UI/StepDefinitions/BlazeDemoSteps.cs
+++ b/UI/StepDefinitions/BlazeDemoSteps.cs
@@ -1,0 +1,32 @@
+using TechTalk.SpecFlow;
+using OpenQA.Selenium;
+using FluentAssertions;
+using AutomationFramework.Core.Config;
+using AutomationFramework.Core.Utilities;
+
+namespace AutomationFramework.UI.StepDefinitions
+{
+    [Binding]
+    public class BlazeDemoSteps
+    {
+        private readonly IWebDriver _driver;
+
+        public BlazeDemoSteps(ScenarioContext scenarioContext)
+        {
+            _driver = (IWebDriver)scenarioContext["WebDriver"];
+        }
+
+        [Given(@"I navigate to '(.*)'")]
+        public void GivenINavigateTo(string url)
+        {
+            _driver.Navigate().GoToUrl(url);
+        }
+
+        [Then(@"the page title should be '(.*)'")]
+        public void ThenThePageTitleShouldBe(string expectedTitle)
+        {
+            var actualTitle = _driver.Title;
+            actualTitle.Should().Be(expectedTitle, $"Expected page title to be {expectedTitle} but was {actualTitle}");
+        }
+    }
+}


### PR DESCRIPTION
This PR adds a new UI test to verify the page title of BlazeDemo website.

- Added a feature file `BlazeDemoTitleVerification.feature`.
- Implemented step definitions in `BlazeDemoSteps.cs`.

Closes #<issue_number>