### PR TITLE
Add test to verify the page title of BlazeDemo website

### DIFF
--- a/UI/Features/VerifyPageTitle.feature
+++ b/UI/Features/VerifyPageTitle.feature
@@ -1,0 +1,11 @@
+#language: en
+
+@UI @Positive
+Feature: Verify Page Title
+  As a user
+  I want to verify the page title of the BlazeDemo website
+  So that I can ensure the correct page is loaded
+
+  Scenario: Verify BlazeDemo Page Title
+    Given I navigate to 'https://blazedemo.com/'
+    Then the page title should be 'BlazeDemo'

--- a/UI/StepDefinitions/VerifyPageTitleSteps.cs
+++ b/UI/StepDefinitions/VerifyPageTitleSteps.cs
@@ -1,0 +1,31 @@
+using TechTalk.SpecFlow;
+using OpenQA.Selenium;
+using FluentAssertions;
+using AutomationFramework.Core.Config;
+
+namespace AutomationFramework.UI.StepDefinitions
+{
+    [Binding]
+    public class VerifyPageTitleSteps
+    {
+        private readonly IWebDriver _driver;
+
+        public VerifyPageTitleSteps(ScenarioContext scenarioContext)
+        {
+            _driver = (IWebDriver)scenarioContext["WebDriver"];
+        }
+
+        [Given(@"I navigate to '(.*)'")]
+        public void GivenINavigateTo(string url)
+        {
+            _driver.Navigate().GoToUrl(url);
+        }
+
+        [Then(@"the page title should be '(.*)'")]
+        public void ThenThePageTitleShouldBe(string expectedTitle)
+        {
+            var actualTitle = _driver.Title;
+            actualTitle.Should().Be(expectedTitle, $"Expected page title to be {expectedTitle} but was {actualTitle}");
+        }
+    }
+}


### PR DESCRIPTION
This PR adds a new UI test to verify the page title of the BlazeDemo website.

- Added a new feature file `VerifyPageTitle.feature`.
- Added new step definitions in `VerifyPageTitleSteps.cs`.

closes #