### PR TITLE
Add test to verify BlazeDemo page title

### DIFF
--- a/UI/Features/BlazeDemoTitleVerification.feature
+++ b/UI/Features/BlazeDemoTitleVerification.feature
@@ -1,0 +1,11 @@
+#language: en
+
+@UI @Positive
+Feature: BlazeDemo Title Verification
+  As a user
+  I want to verify the page title of BlazeDemo
+  So that I can ensure the correct page is loaded
+
+  Scenario: Verify the page title of BlazeDemo
+    Given I navigate to 'https://blazedemo.com/'
+    Then the page title should be 'BlazeDemo'

--- a/UI/StepDefinitions/BlazeDemoTitleSteps.cs
+++ b/UI/StepDefinitions/BlazeDemoTitleSteps.cs
@@ -1,0 +1,32 @@
+using TechTalk.SpecFlow;
+using AutomationFramework.Core.Config;
+using OpenQA.Selenium;
+using FluentAssertions;
+using AutomationFramework.Core.Utilities;
+
+namespace AutomationFramework.UI.StepDefinitions
+{
+    [Binding]
+    public class BlazeDemoTitleSteps
+    {
+        private readonly IWebDriver _driver;
+
+        public BlazeDemoTitleSteps(ScenarioContext scenarioContext)
+        {
+            _driver = (IWebDriver)scenarioContext["WebDriver"];
+        }
+
+        [Given(@"I navigate to '(.*)'")]
+        public void GivenINavigateTo(string url)
+        {
+            _driver.Navigate().GoToUrl(url);
+        }
+
+        [Then(@"the page title should be '(.*)'")]
+        public void ThenThePageTitleShouldBe(string expectedTitle)
+        {
+            var actualTitle = _driver.Title;
+            actualTitle.Should().Be(expectedTitle, $"Expected page title to be {expectedTitle} but was {actualTitle}");
+        }
+    }
+}


### PR DESCRIPTION
This PR adds a new UI test to verify the page title of BlazeDemo.

Feature file: `BlazeDemoTitleVerification.feature`
Step definitions: `BlazeDemoTitleSteps.cs`

The test navigates to `https://blazedemo.com/` and verifies that the page title is `BlazeDemo`.