### PR TITLE
Add test to verify BlazeDemo page title

### DIFF
--- a/UI/Features/VerifyBlazeDemoTitle.feature
+++ b/UI/Features/VerifyBlazeDemoTitle.feature
@@ -1,0 +1,6 @@
+Feature: Verify BlazeDemo Page Title
+
+  @UI @Positive
+  Scenario: Verify the page title of BlazeDemo
+    Given I navigate to 'https://blazedemo.com/'
+    Then the page title should be 'BlazeDemo'

--- a/UI/StepDefinitions/BlazeDemoSteps.cs
+++ b/UI/StepDefinitions/BlazeDemoSteps.cs
@@ -1,0 +1,31 @@
+using TechTalk.SpecFlow;
+using AutomationFramework.UI.BusinessLogic;
+using AutomationFramework.Core.Config;
+using OpenQA.Selenium;
+using FluentAssertions;
+
+namespace AutomationFramework.UI.StepDefinitions
+{
+    [Binding]
+    public class BlazeDemoSteps
+    {
+        private readonly IWebDriver _driver;
+
+        public BlazeDemoSteps(ScenarioContext scenarioContext)
+        {
+            _driver = (IWebDriver)scenarioContext["WebDriver"];
+        }
+
+        [Given(@"I navigate to 'https://blazedemo.com/'")]
+        public void GivenINavigateToBlazeDemo()
+        {
+            _driver.Navigate().GoToUrl("https://blazedemo.com/");
+        }
+
+        [Then(@"the page title should be 'BlazeDemo'")]
+        public void ThenThePageTitleShouldBeBlazeDemo()
+        {
+            _driver.Title.Should().Be("BlazeDemo", "Page title should be BlazeDemo");
+        }
+    }
+}


### PR DESCRIPTION
This PR adds a new test to verify the page title of BlazeDemo.

Feature file: VerifyBlazeDemoTitle.feature
Step definitions: BlazeDemoSteps.cs

closes #123