### PR TITLE
Add test to verify BlazeDemo page title

### DIFF
--- a/UI/Features/BlazeDemoPageTitle.feature
+++ b/UI/Features/BlazeDemoPageTitle.feature
@@ -1,0 +1,6 @@
+Feature: Verify BlazeDemo Page Title
+
+  @UI @Positive
+  Scenario: Verify the page title of BlazeDemo
+    Given I navigate to BlazeDemo page
+    Then the page title should be 'BlazeDemo'

--- a/UI/StepDefinitions/BlazeDemoSteps.cs
+++ b/UI/StepDefinitions/BlazeDemoSteps.cs
@@ -1,0 +1,45 @@
+using TechTalk.SpecFlow;
+using AutomationFramework.Core.Config;
+using OpenQA.Selenium;
+using FluentAssertions;
+using AutomationFramework.Core.Utilities;
+using AutomationFramework.Core.Singleton;
+using NUnit.Framework;
+using SeleniumExtras.WaitHelpers;
+using OpenQA.Selenium.Support.UI;
+
+namespace AutomationFramework.UI.StepDefinitions
+{
+    [Binding]
+    public class BlazeDemoSteps
+    {
+        private readonly IWebDriver _driver;
+
+        public BlazeDemoSteps(ScenarioContext scenarioContext)
+        {
+            _driver = (IWebDriver)scenarioContext["WebDriver"];
+        }
+
+        [Given("I navigate to BlazeDemo page")]
+        public void GivenINavigateToBlazeDemoPage()
+        {
+            var url = "https://blazedemo.com/";
+            _driver.Navigate().GoToUrl(url);
+        }
+
+        [Then("the page title should be '(.*)'")]
+        public void ThenThePageTitleShouldBe(string expectedTitle)
+        {
+            try
+            {
+                var actualTitle = _driver.Title;
+                Assert.That(actualTitle, Is.EqualTo(expectedTitle), $"Expected page title to be '{expectedTitle}' but was '{actualTitle}'");
+            }
+            catch (Exception ex)
+            {
+                ScreenshotHelper.CaptureScreenshot(_driver, "BlazeDemoPageTitleError");
+                throw new AssertionException($"An error occurred while verifying the page title: {ex.Message}");
+            }
+        }
+    }
+}


### PR DESCRIPTION
This PR adds a new UI test to verify the page title of BlazeDemo.

- Added `BlazeDemoPageTitle.feature` file with the scenario to verify the page title.
- Added `BlazeDemoSteps.cs` file with step definitions for navigating to BlazeDemo page and verifying the page title.

closes #1