### PR TITLE
Add test to verify the page title of BlazeDemo

### DIFF
--- a/UI/Features/BlazeDemoPageTitle.feature
+++ b/UI/Features/BlazeDemoPageTitle.feature
@@ -1,0 +1,6 @@
+@UI @Positive
+Feature: BlazeDemo Page Title Verification
+
+  Scenario: Verify the page title of BlazeDemo
+    Given I navigate to 'https://blazedemo.com/'
+    Then the page title should be 'BlazeDemo'

--- a/UI/StepDefinitions/BlazeDemoSteps.cs
+++ b/UI/StepDefinitions/BlazeDemoSteps.cs
@@ -1,0 +1,31 @@
+using TechTalk.SpecFlow;
+using OpenQA.Selenium;
+using FluentAssertions;
+using AutomationFramework.Core.Config;
+
+namespace AutomationFramework.UI.StepDefinitions
+{
+    [Binding]
+    public class BlazeDemoSteps
+    {
+        private readonly IWebDriver _driver;
+
+        public BlazeDemoSteps(ScenarioContext scenarioContext)
+        {
+            _driver = (IWebDriver)scenarioContext["WebDriver"];
+        }
+
+        [Given(@"I navigate to '(.*)'")]
+        public void GivenINavigateTo(string url)
+        {
+            _driver.Navigate().GoToUrl(url);
+        }
+
+        [Then(@"the page title should be '(.*)'")]
+        public void ThenThePageTitleShouldBe(string expectedTitle)
+        {
+            var actualTitle = _driver.Title;
+            actualTitle.Should().Be(expectedTitle, $"The page title should be '{expectedTitle}' but was '{actualTitle}'");
+        }
+    }
+}


### PR DESCRIPTION
This PR adds a new test to verify the page title of BlazeDemo.

- Added a new feature file `BlazeDemoPageTitle.feature` under `UI/Features`.
- Added a new step definition file `BlazeDemoSteps.cs` under `UI/StepDefinitions`.
- The test navigates to `https://blazedemo.com/` and verifies that the page title is `BlazeDemo`.

closes #<issue_number>